### PR TITLE
Method to return all {tag,branch} + revision as tuples

### DIFF
--- a/bzr_test.go
+++ b/bzr_test.go
@@ -3,6 +3,7 @@ package vcs
 import (
 	"io/ioutil"
 	"time"
+
 	//"log"
 	"os"
 	"testing"
@@ -121,6 +122,26 @@ func TestBzr(t *testing.T) {
 	}
 	if tags[0] != "1.0.0" {
 		t.Error("Bzr tags is not reporting the correct version")
+	}
+
+	vs, s, err := repo.CurrentVersionsWithRevs()
+	if err != nil {
+		t.Error(err)
+	}
+	if !s {
+		t.Error("bzr version-grabbing should always sync the branch")
+	}
+	if len(vs) != 1 {
+		t.Errorf("Returned versions slice is the wrong length; should be 1, got %v", len(vs))
+	} else {
+		// Do this in an else branch to ensure no panic on a slice OOB error
+		cmp := VersionInfo{
+			Name:     "1.0.0",
+			Revision: "matt@mattfarina.com-20150731135137-pbphasfppmygpl68",
+		}
+		if vs[0] != cmp {
+			t.Errorf("Returned tag was incorrect; got %s", vs[0])
+		}
 	}
 
 	branches, err := repo.Branches()

--- a/git_test.go
+++ b/git_test.go
@@ -3,6 +3,7 @@ package vcs
 import (
 	"io/ioutil"
 	"time"
+
 	//"log"
 	"os"
 	"testing"
@@ -139,6 +140,45 @@ func TestGit(t *testing.T) {
 	}
 	if tags[0] != "1.0.0" {
 		t.Error("Git tags is not reporting the correct version")
+	}
+
+	vrevs, updated, err := repo.CurrentVersionsWithRevs()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if updated {
+		t.Error("Git CurrentVersionsWithRevs updated local repo, but should not have needed to")
+	}
+
+	vr := VersionInfo{
+		IsBranch: true,
+		Name:     "master",
+		Revision: "30605f6ac35fcb075ad0bfa9296f90a7d891523e",
+	}
+
+	if vrevs[0] != vr {
+		t.Errorf("Git CurrentVersionsWithRevs reporting incorrect first version, got %v", vrevs[0])
+	}
+
+	vr = VersionInfo{
+		IsBranch: true,
+		Name:     "test",
+		Revision: "30605f6ac35fcb075ad0bfa9296f90a7d891523e",
+	}
+
+	if vrevs[1] != vr {
+		t.Errorf("Git CurrentVersionsWithRevs reporting incorrect first version, got %v", vrevs[1])
+	}
+
+	vr = VersionInfo{
+		IsBranch: false,
+		Name:     "1.0.0",
+		Revision: "30605f6ac35fcb075ad0bfa9296f90a7d891523e",
+	}
+
+	if vrevs[2] != vr {
+		t.Errorf("Git CurrentVersionsWithRevs reporting incorrect first version, got %v", vrevs[2])
 	}
 
 	branches, err := repo.Branches()

--- a/hg.go
+++ b/hg.go
@@ -1,6 +1,7 @@
 package vcs
 
 import (
+	"bytes"
 	"encoding/xml"
 	"os"
 	"os/exec"
@@ -142,6 +143,74 @@ func (s *HgRepo) Tags() ([]string, error) {
 	}
 	tags := s.referenceList(string(out), `(?m-s)^(\S+)`)
 	return tags, nil
+}
+
+// CurrentVersionsWithRevs returns a list of available branches and tags, and
+// their underlying revision identifiers. The list is guaranteed to be current.
+//
+// TODO currently, this only retrieves the tags known to whatever the checked
+// out branch happens to be. This is kinda horribly broken.
+func (s *HgRepo) CurrentVersionsWithRevs() (versions []VersionInfo, localSynced bool, err error) {
+	var out []byte
+	err = s.Update()
+	if err != nil {
+		return
+	}
+
+	localSynced = true
+	out, err = s.runFromDir("hg", "tags", "--debug", "--verbose")
+	if err != nil {
+		return
+	}
+
+	all := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
+	lbyt := []byte("local")
+	for _, line := range all {
+		if bytes.Equal(lbyt, line[len(line)-len(lbyt):]) {
+			// Skip local tags
+			continue
+		}
+
+		// tip is magic, don't include it
+		if bytes.HasPrefix(line, []byte("tip")) {
+			continue
+		}
+
+		// Split on colon; this gets us the rev and the tag plus local revno
+		pair := bytes.Split(line, []byte(":"))
+		idx := bytes.IndexByte(pair[0], 32) // space
+		versions = append(versions, VersionInfo{
+			Name:     string(pair[0][:idx]),
+			Revision: string(pair[1]),
+		})
+	}
+
+	out, err = s.runFromDir("hg", "branches", "--debug", "--verbose")
+	if err != nil {
+		// better nothing than incomplete
+		versions = nil
+		return
+	}
+
+	all = bytes.Split(bytes.TrimSpace(out), []byte("\n"))
+	lbyt = []byte("(inactive)")
+	for _, line := range all {
+		if bytes.Equal(lbyt, line[len(line)-len(lbyt):]) {
+			// Skip inactive branches
+			continue
+		}
+
+		// Split on colon; this gets us the rev and the branch plus local revno
+		pair := bytes.Split(line, []byte(":"))
+		idx := bytes.IndexByte(pair[0], 32) // space
+		versions = append(versions, VersionInfo{
+			IsBranch: true,
+			Name:     string(pair[0][:idx]),
+			Revision: string(pair[1]),
+		})
+	}
+
+	return
 }
 
 // IsReference returns if a string is a reference. A reference can be a

--- a/hg_test.go
+++ b/hg_test.go
@@ -3,6 +3,7 @@ package vcs
 import (
 	"io/ioutil"
 	"time"
+
 	//"log"
 	"os"
 	"testing"
@@ -121,6 +122,33 @@ func TestHg(t *testing.T) {
 	}
 	if tags[1] != "1.0.0" {
 		t.Error("Hg tags is not reporting the correct version")
+	}
+
+	vs, s, err := repo.CurrentVersionsWithRevs()
+	if err != nil {
+		t.Error(err)
+	}
+	if !s {
+		t.Error("Hg version-grabbing should always sync the local")
+	}
+	if len(vs) != 2 {
+		t.Errorf("Returned versions slice is the wrong length; should be 2, got %v", len(vs))
+	} else {
+		cmp := VersionInfo{
+			Name:     "1.0.0",
+			Revision: "d680e82228d206935ab2eaa88612587abe68db07",
+		}
+		if vs[0] != cmp {
+			t.Errorf("Returned tag was incorrect; got %s", vs[0])
+		}
+		cmp = VersionInfo{
+			IsBranch: true,
+			Name:     "test",
+			Revision: "6c44ee3fe5d87763616c19bf7dbcadb24ff5a5ce",
+		}
+		if vs[1] != cmp {
+			t.Errorf("Returned branch was incorrect; got %s", vs[0])
+		}
 	}
 
 	branches, err := repo.Branches()

--- a/repo.go
+++ b/repo.go
@@ -118,6 +118,11 @@ type Repo interface {
 	// Tags returns a list of available tags on the repository.
 	Tags() ([]string, error)
 
+	// CurrentVersionWithRevs returns the most recent versions of branches and
+	// tags available from the repository. If the local repository's state (in
+	// the case of a DVCS) was updated, the second return will be true.
+	CurrentVersionsWithRevs() (versions []VersionInfo, localSynced bool, err error)
+
 	// TODO: Provide a consistent manner to get reference information across
 	// multiple VCS.
 

--- a/repo.go
+++ b/repo.go
@@ -133,6 +133,14 @@ type Repo interface {
 	CommitInfo(string) (*CommitInfo, error)
 }
 
+// VersionInfo is a triplet of information - a version, its corresponding
+// underlying immutable revision, and a boolean indicating whether the version
+// is a branch or a tag.
+type VersionInfo struct {
+	IsBranch       bool
+	Name, Revision string
+}
+
 // NewRepo returns a Repo based on trying to detect the source control from the
 // remote and local locations. The appropriate implementation will be returned
 // or an ErrCannotDetectVCS if the VCS type cannot be detected.

--- a/svn.go
+++ b/svn.go
@@ -141,6 +141,13 @@ func (s *SvnRepo) Branches() ([]string, error) {
 	return []string{}, nil
 }
 
+// CurrentVersionsWithRevs is supposed to returns a list of available branches and tags, and
+// their underlying revision identifiers. This is mostly just untenable for SVN,
+// so for now, we're punting on it.
+func (s *SvnRepo) CurrentVersionsWithRevs() (versions []VersionInfo, localSynced bool, err error) {
+	return nil, false, nil
+}
+
 // IsReference returns if a string is a reference. A reference is a commit id.
 // Branches and tags are part of the path.
 func (s *SvnRepo) IsReference(r string) bool {

--- a/svn_test.go
+++ b/svn_test.go
@@ -142,6 +142,17 @@ func TestSvn(t *testing.T) {
 		t.Error("Svn is incorrectly returning branches")
 	}
 
+	vs, s, err := repo.CurrentVersionsWithRevs()
+	if err != nil {
+		t.Error(err)
+	}
+	if s {
+		t.Error("Svn is incorrectly reporting 'local' synchronization")
+	}
+	if vs != nil {
+		t.Error("Svn is incorrectly returning VersionInfo pairs")
+	}
+
 	if repo.IsReference("r4") != true {
 		t.Error("Svn is reporting a reference is not one")
 	}


### PR DESCRIPTION
Listing out versions+revs cheaply - ideally, as a single command - is a requirement for [vsolver](https://github.com/sdboyer/vsolver). This doesn't happen for every project on every solver run - if there's lock file data from the top-level project, we can avoid it (unless/until a conflict is encountered, or if an update is requested). However, it's the first contact made with disk/network, so keeping it as spritely as possible is crucial. That's really only feasible to do if we have a separate command for it.

Also sorta-enmeshed with this is needing to know if the local version of the repo (assuming a dvcs) is out of sync with the upstream - that is, if branches (or, ugh ugh, tags) point to different revisions in the canonical upstream repository than they do locally. In the interests of my own implementation simplicity, my preference is for a method that, assuming the canonical repo still exists, is guaranteed to return the current information. I still have desync to deal with from other quarters, but not having to deal with it here is one less dimension.

This PR is more intended as a basis of discussion than for directly merging; for this particular purpose, it represents my ideal. So, let's discuss from here :)

(in some ways, this is kinda the inverse of #19, or in some way obviates the need for it - with all this information on hand, you can trivially do the lookup yourself.)