### PR TITLE
Make RunFromDir exportable

### DIFF
--- a/bzr.go
+++ b/bzr.go
@@ -81,24 +81,24 @@ func (s *BzrRepo) Get() error {
 
 // Update performs a Bzr pull and update to an existing checkout.
 func (s *BzrRepo) Update() error {
-	_, err := s.runFromDir("bzr", "pull")
+	_, err := s.RunFromDir("bzr", "pull")
 	if err != nil {
 		return err
 	}
-	_, err = s.runFromDir("bzr", "update")
+	_, err = s.RunFromDir("bzr", "update")
 	return err
 }
 
 // UpdateVersion sets the version of a package currently checked out via Bzr.
 func (s *BzrRepo) UpdateVersion(version string) error {
-	_, err := s.runFromDir("bzr", "update", "-r", version)
+	_, err := s.RunFromDir("bzr", "update", "-r", version)
 	return err
 }
 
 // Version retrieves the current version.
 func (s *BzrRepo) Version() (string, error) {
 
-	out, err := s.runFromDir("bzr", "revno", "--tree")
+	out, err := s.RunFromDir("bzr", "revno", "--tree")
 	if err != nil {
 		return "", err
 	}
@@ -108,7 +108,7 @@ func (s *BzrRepo) Version() (string, error) {
 
 // Date retrieves the date on the latest commit.
 func (s *BzrRepo) Date() (time.Time, error) {
-	out, err := s.runFromDir("bzr", "version-info", "--custom", "--template={date}")
+	out, err := s.RunFromDir("bzr", "version-info", "--custom", "--template={date}")
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -139,7 +139,7 @@ func (s *BzrRepo) Branches() ([]string, error) {
 
 // Tags returns a list of available tags on the repository.
 func (s *BzrRepo) Tags() ([]string, error) {
-	out, err := s.runFromDir("bzr", "tags")
+	out, err := s.RunFromDir("bzr", "tags")
 	if err != nil {
 		return []string{}, err
 	}
@@ -150,7 +150,7 @@ func (s *BzrRepo) Tags() ([]string, error) {
 // IsReference returns if a string is a reference. A reference can be a
 // commit id or tag.
 func (s *BzrRepo) IsReference(r string) bool {
-	_, err := s.runFromDir("bzr", "revno", "-r", r)
+	_, err := s.RunFromDir("bzr", "revno", "-r", r)
 	if err == nil {
 		return true
 	}
@@ -161,14 +161,14 @@ func (s *BzrRepo) IsReference(r string) bool {
 // IsDirty returns if the checkout has been modified from the checked
 // out reference.
 func (s *BzrRepo) IsDirty() bool {
-	out, err := s.runFromDir("bzr", "diff")
+	out, err := s.RunFromDir("bzr", "diff")
 	return err != nil || len(out) != 0
 }
 
 // CommitInfo retrieves metadata about a commit.
 func (s *BzrRepo) CommitInfo(id string) (*CommitInfo, error) {
 	r := "-r" + id
-	out, err := s.runFromDir("bzr", "log", r, "--log-format=long")
+	out, err := s.RunFromDir("bzr", "log", r, "--log-format=long")
 	if err != nil {
 		return nil, ErrRevisionUnavailable
 	}

--- a/git.go
+++ b/git.go
@@ -90,7 +90,7 @@ func (s *GitRepo) Get() error {
 // Update performs an Git fetch and pull to an existing checkout.
 func (s *GitRepo) Update() error {
 	// Perform a fetch to make sure everything is up to date.
-	_, err := s.runFromDir("git", "fetch", s.RemoteLocation)
+	_, err := s.RunFromDir("git", "fetch", s.RemoteLocation)
 	if err != nil {
 		return err
 	}
@@ -107,19 +107,19 @@ func (s *GitRepo) Update() error {
 		return nil
 	}
 
-	_, err = s.runFromDir("git", "pull")
+	_, err = s.RunFromDir("git", "pull")
 	return err
 }
 
 // UpdateVersion sets the version of a package currently checked out via Git.
 func (s *GitRepo) UpdateVersion(version string) error {
-	_, err := s.runFromDir("git", "checkout", version)
+	_, err := s.RunFromDir("git", "checkout", version)
 	return err
 }
 
 // Version retrieves the current version.
 func (s *GitRepo) Version() (string, error) {
-	out, err := s.runFromDir("git", "rev-parse", "HEAD")
+	out, err := s.RunFromDir("git", "rev-parse", "HEAD")
 	if err != nil {
 		return "", err
 	}
@@ -129,7 +129,7 @@ func (s *GitRepo) Version() (string, error) {
 
 // Date retrieves the date on the latest commit.
 func (s *GitRepo) Date() (time.Time, error) {
-	out, err := s.runFromDir("git", "log", "-1", "--date=iso", "--pretty=format:%cd")
+	out, err := s.RunFromDir("git", "log", "-1", "--date=iso", "--pretty=format:%cd")
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -142,7 +142,7 @@ func (s *GitRepo) Date() (time.Time, error) {
 
 // Branches returns a list of available branches on the RemoteLocation
 func (s *GitRepo) Branches() ([]string, error) {
-	out, err := s.runFromDir("git", "show-ref")
+	out, err := s.RunFromDir("git", "show-ref")
 	if err != nil {
 		return []string{}, err
 	}
@@ -152,7 +152,7 @@ func (s *GitRepo) Branches() ([]string, error) {
 
 // Tags returns a list of available tags on the RemoteLocation
 func (s *GitRepo) Tags() ([]string, error) {
-	out, err := s.runFromDir("git", "show-ref")
+	out, err := s.RunFromDir("git", "show-ref")
 	if err != nil {
 		return []string{}, err
 	}
@@ -172,7 +172,7 @@ func (s *GitRepo) CheckLocal() bool {
 // IsReference returns if a string is a reference. A reference can be a
 // commit id, branch, or tag.
 func (s *GitRepo) IsReference(r string) bool {
-	_, err := s.runFromDir("git", "rev-parse", "--verify", r)
+	_, err := s.RunFromDir("git", "rev-parse", "--verify", r)
 	if err == nil {
 		return true
 	}
@@ -180,7 +180,7 @@ func (s *GitRepo) IsReference(r string) bool {
 	// Some refs will fail rev-parse. For example, a remote branch that has
 	// not been checked out yet. This next step should pickup the other
 	// possible references.
-	_, err = s.runFromDir("git", "show-ref", r)
+	_, err = s.RunFromDir("git", "show-ref", r)
 	if err == nil {
 		return true
 	}
@@ -191,14 +191,14 @@ func (s *GitRepo) IsReference(r string) bool {
 // IsDirty returns if the checkout has been modified from the checked
 // out reference.
 func (s *GitRepo) IsDirty() bool {
-	out, err := s.runFromDir("git", "diff")
+	out, err := s.RunFromDir("git", "diff")
 	return err != nil || len(out) != 0
 }
 
 // CommitInfo retrieves metadata about a commit.
 func (s *GitRepo) CommitInfo(id string) (*CommitInfo, error) {
 	fm := `--pretty=format:"<logentry><commit>%H</commit><author>%an &lt;%ae&gt;</author><date>%aD</date><message>%s</message></logentry>"`
-	out, err := s.runFromDir("git", "log", id, fm, "-1")
+	out, err := s.RunFromDir("git", "log", id, fm, "-1")
 	if err != nil {
 		return nil, ErrRevisionUnavailable
 	}

--- a/hg.go
+++ b/hg.go
@@ -72,23 +72,23 @@ func (s *HgRepo) Get() error {
 
 // Update performs a Mercurial pull to an existing checkout.
 func (s *HgRepo) Update() error {
-	_, err := s.runFromDir("hg", "update")
+	_, err := s.RunFromDir("hg", "update")
 	return err
 }
 
 // UpdateVersion sets the version of a package currently checked out via Hg.
 func (s *HgRepo) UpdateVersion(version string) error {
-	_, err := s.runFromDir("hg", "pull")
+	_, err := s.RunFromDir("hg", "pull")
 	if err != nil {
 		return err
 	}
-	_, err = s.runFromDir("hg", "update", version)
+	_, err = s.RunFromDir("hg", "update", version)
 	return err
 }
 
 // Version retrieves the current version.
 func (s *HgRepo) Version() (string, error) {
-	out, err := s.runFromDir("hg", "identify")
+	out, err := s.RunFromDir("hg", "identify")
 	if err != nil {
 		return "", err
 	}
@@ -104,7 +104,7 @@ func (s *HgRepo) Date() (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	out, err := s.runFromDir("hg", "log", "-r", version, "--template", "{date|isodatesec}")
+	out, err := s.RunFromDir("hg", "log", "-r", version, "--template", "{date|isodatesec}")
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -126,7 +126,7 @@ func (s *HgRepo) CheckLocal() bool {
 
 // Branches returns a list of available branches
 func (s *HgRepo) Branches() ([]string, error) {
-	out, err := s.runFromDir("hg", "branches")
+	out, err := s.RunFromDir("hg", "branches")
 	if err != nil {
 		return []string{}, err
 	}
@@ -136,7 +136,7 @@ func (s *HgRepo) Branches() ([]string, error) {
 
 // Tags returns a list of available tags
 func (s *HgRepo) Tags() ([]string, error) {
-	out, err := s.runFromDir("hg", "tags")
+	out, err := s.RunFromDir("hg", "tags")
 	if err != nil {
 		return []string{}, err
 	}
@@ -147,7 +147,7 @@ func (s *HgRepo) Tags() ([]string, error) {
 // IsReference returns if a string is a reference. A reference can be a
 // commit id, branch, or tag.
 func (s *HgRepo) IsReference(r string) bool {
-	_, err := s.runFromDir("hg", "log", "-r", r)
+	_, err := s.RunFromDir("hg", "log", "-r", r)
 	if err == nil {
 		return true
 	}
@@ -158,13 +158,13 @@ func (s *HgRepo) IsReference(r string) bool {
 // IsDirty returns if the checkout has been modified from the checked
 // out reference.
 func (s *HgRepo) IsDirty() bool {
-	out, err := s.runFromDir("hg", "diff")
+	out, err := s.RunFromDir("hg", "diff")
 	return err != nil || len(out) != 0
 }
 
 // CommitInfo retrieves metadata about a commit.
 func (s *HgRepo) CommitInfo(id string) (*CommitInfo, error) {
-	out, err := s.runFromDir("hg", "log", "-r", id, "--style=xml")
+	out, err := s.RunFromDir("hg", "log", "-r", id, "--style=xml")
 	if err != nil {
 		return nil, ErrRevisionUnavailable
 	}

--- a/repo.go
+++ b/repo.go
@@ -134,6 +134,9 @@ type Repo interface {
 
 	// Ping returns if remote location is accessible.
 	Ping() bool
+
+	// Runs a command from repo's directory.
+	RunFromDir(cmd string, args ...string) ([]byte, error)
 }
 
 // NewRepo returns a Repo based on trying to detect the source control from the
@@ -222,7 +225,7 @@ func (b base) run(cmd string, args ...string) ([]byte, error) {
 	return out, err
 }
 
-func (b *base) runFromDir(cmd string, args ...string) ([]byte, error) {
+func (b *base) RunFromDir(cmd string, args ...string) ([]byte, error) {
 	c := exec.Command(cmd, args...)
 	c.Dir = b.local
 	c.Env = envForDir(c.Dir)

--- a/svn.go
+++ b/svn.go
@@ -73,19 +73,19 @@ func (s *SvnRepo) Get() error {
 
 // Update performs an SVN update to an existing checkout.
 func (s *SvnRepo) Update() error {
-	_, err := s.runFromDir("svn", "update")
+	_, err := s.RunFromDir("svn", "update")
 	return err
 }
 
 // UpdateVersion sets the version of a package currently checked out via SVN.
 func (s *SvnRepo) UpdateVersion(version string) error {
-	_, err := s.runFromDir("svn", "update", "-r", version)
+	_, err := s.RunFromDir("svn", "update", "-r", version)
 	return err
 }
 
 // Version retrieves the current version.
 func (s *SvnRepo) Version() (string, error) {
-	out, err := s.runFromDir("svnversion", ".")
+	out, err := s.RunFromDir("svnversion", ".")
 	s.log(out)
 	if err != nil {
 		return "", err
@@ -99,7 +99,7 @@ func (s *SvnRepo) Date() (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	out, err := s.runFromDir("svn", "pget", "svn:date", "--revprop", "-r", version)
+	out, err := s.RunFromDir("svn", "pget", "svn:date", "--revprop", "-r", version)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -144,7 +144,7 @@ func (s *SvnRepo) Branches() ([]string, error) {
 // IsReference returns if a string is a reference. A reference is a commit id.
 // Branches and tags are part of the path.
 func (s *SvnRepo) IsReference(r string) bool {
-	out, err := s.runFromDir("svn", "log", "-r", r)
+	out, err := s.RunFromDir("svn", "log", "-r", r)
 
 	// This is a complete hack. There must be a better way to do this. Pull
 	// requests welcome. When the reference isn't real you get a line of
@@ -162,13 +162,13 @@ func (s *SvnRepo) IsReference(r string) bool {
 // IsDirty returns if the checkout has been modified from the checked
 // out reference.
 func (s *SvnRepo) IsDirty() bool {
-	out, err := s.runFromDir("svn", "diff")
+	out, err := s.RunFromDir("svn", "diff")
 	return err != nil || len(out) != 0
 }
 
 // CommitInfo retrieves metadata about a commit.
 func (s *SvnRepo) CommitInfo(id string) (*CommitInfo, error) {
-	out, err := s.runFromDir("svn", "log", "-r", id, "--xml")
+	out, err := s.RunFromDir("svn", "log", "-r", id, "--xml")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It turns out in practice having ``RunFromDir`` available when using ``Repo`` objects is very helpful.

A commonality across VCS is running commands from the root dir of the repo.

In its current form, since ``runFromDir`` is unexported, you have to try to reimplement it on your own in some way. For instance creating separate functions to get ``LocalPath()`` and run ``os.Exec`` each time. This leads downstream to a lot of code bases imitating reinventing the wheel of what ``runFromDir`` already does well.