### PR TITLE
Implements #36: Get current version-ish

### DIFF
--- a/bzr.go
+++ b/bzr.go
@@ -147,6 +147,36 @@ func (s *BzrRepo) Version() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// Current returns the current version-ish. This means:
+// * -1 if on the tip of the branch (this is the Bzr value for HEAD)
+// * A tag if on a tag
+// * Otherwise a revision
+func (s *BzrRepo) Current() (string, error) {
+	tip, err := s.CommitInfo("-1")
+	if err != nil {
+		return "", err
+	}
+
+	curr, err := s.Version()
+	if err != nil {
+		return "", err
+	}
+
+	if tip.Commit == curr {
+		return "-1", nil
+	}
+
+	ts, err := s.TagsFromCommit(curr)
+	if err != nil {
+		return "", err
+	}
+	if len(ts) > 0 {
+		return ts[0], nil
+	}
+
+	return curr, nil
+}
+
 // Date retrieves the date on the latest commit.
 func (s *BzrRepo) Date() (time.Time, error) {
 	out, err := s.RunFromDir("bzr", "version-info", "--custom", "--template={date}")
@@ -214,9 +244,7 @@ func (s *BzrRepo) CommitInfo(id string) (*CommitInfo, error) {
 		return nil, ErrRevisionUnavailable
 	}
 
-	ci := &CommitInfo{
-		Commit: id,
-	}
+	ci := &CommitInfo{}
 	lines := strings.Split(string(out), "\n")
 	const format = "Mon 2006-01-02 15:04:05 -0700"
 	var track int
@@ -224,7 +252,9 @@ func (s *BzrRepo) CommitInfo(id string) (*CommitInfo, error) {
 
 	// Note, bzr does not appear to use i18m.
 	for i, l := range lines {
-		if strings.HasPrefix(l, "committer:") {
+		if strings.HasPrefix(l, "revno:") {
+			ci.Commit = strings.TrimSpace(strings.TrimPrefix(l, "revno:"))
+		} else if strings.HasPrefix(l, "committer:") {
 			ci.Author = strings.TrimSpace(strings.TrimPrefix(l, "committer:"))
 		} else if strings.HasPrefix(l, "timestamp:") {
 			ts := strings.TrimSpace(strings.TrimPrefix(l, "timestamp:"))

--- a/bzr_test.go
+++ b/bzr_test.go
@@ -78,18 +78,34 @@ func TestBzr(t *testing.T) {
 		t.Error("Wrong version returned from NewRepo")
 	}
 
+	v, err := repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Bzr Current: %s", err)
+	}
+	if v != "-1" {
+		t.Errorf("Current failed to detect Bzr on tip of branch. Got version: %s", v)
+	}
+
 	err = repo.UpdateVersion("2")
 	if err != nil {
 		t.Errorf("Unable to update Bzr repo version. Err was %s", err)
 	}
 
 	// Use Version to verify we are on the right version.
-	v, err := repo.Version()
+	v, err = repo.Version()
 	if v != "2" {
 		t.Error("Error checking checked out Bzr version")
 	}
 	if err != nil {
 		t.Error(err)
+	}
+
+	v, err = repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Bzr Current: %s", err)
+	}
+	if v != "2" {
+		t.Errorf("Current failed to detect Bzr on rev 2 of branch. Got version: %s", v)
 	}
 
 	// Use Date to verify we are on the right commit.

--- a/git.go
+++ b/git.go
@@ -169,6 +169,34 @@ func (s *GitRepo) Version() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// Current returns the current version-ish. This means:
+// * Branch name if on the tip of the branch
+// * Tag if on a tag
+// * Otherwise a revision id
+func (s *GitRepo) Current() (string, error) {
+	out, err := s.RunFromDir("git", "symbolic-ref", "HEAD")
+	if err == nil {
+		o := bytes.TrimSpace(bytes.TrimPrefix(out, []byte("refs/heads/")))
+		return string(o), nil
+	}
+
+	v, err := s.Version()
+	if err != nil {
+		return "", err
+	}
+
+	ts, err := s.TagsFromCommit(v)
+	if err != nil {
+		return "", err
+	}
+
+	if len(ts) > 0 {
+		return ts[0], nil
+	}
+
+	return v, nil
+}
+
 // Date retrieves the date on the latest commit.
 func (s *GitRepo) Date() (time.Time, error) {
 	out, err := s.RunFromDir("git", "log", "-1", "--date=iso", "--pretty=format:%cd")

--- a/git_test.go
+++ b/git_test.go
@@ -82,6 +82,14 @@ func TestGit(t *testing.T) {
 		t.Error(err)
 	}
 
+	v, err := repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Git Current: %s", err)
+	}
+	if v != "master" {
+		t.Errorf("Current failed to detect Git on tip of master. Got version: %s", v)
+	}
+
 	// Set the version using the short hash.
 	err = repo.UpdateVersion("806b07b")
 	if err != nil {
@@ -98,12 +106,20 @@ func TestGit(t *testing.T) {
 	}
 
 	// Use Version to verify we are on the right version.
-	v, err := repo.Version()
+	v, err = repo.Version()
 	if v != "806b07b08faa21cfbdae93027904f80174679402" {
 		t.Error("Error checking checked out Git version")
 	}
 	if err != nil {
 		t.Error(err)
+	}
+
+	v, err = repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Git Current for ref: %s", err)
+	}
+	if v != "806b07b08faa21cfbdae93027904f80174679402" {
+		t.Errorf("Current failed to detect Git on ref of branch. Got version: %s", v)
 	}
 
 	// Use Date to verify we are on the right commit.

--- a/hg_test.go
+++ b/hg_test.go
@@ -78,6 +78,14 @@ func TestHg(t *testing.T) {
 		t.Error("Wrong version returned from NewRepo")
 	}
 
+	v, err := repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Hg Current: %s", err)
+	}
+	if v != "default" {
+		t.Errorf("Current failed to detect Hg on tip of default. Got version: %s", v)
+	}
+
 	// Set the version using the short hash.
 	err = repo.UpdateVersion("a5494ba2177f")
 	if err != nil {
@@ -85,12 +93,20 @@ func TestHg(t *testing.T) {
 	}
 
 	// Use Version to verify we are on the right version.
-	v, err := repo.Version()
-	if v != "a5494ba2177f" {
-		t.Error("Error checking checked out Hg version")
+	v, err = repo.Version()
+	if v != "a5494ba2177ff9ef26feb3c155dfecc350b1a8ef" {
+		t.Errorf("Error checking checked out Hg version: %s", v)
 	}
 	if err != nil {
 		t.Error(err)
+	}
+
+	v, err = repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Hg Current for ref: %s", err)
+	}
+	if v != "a5494ba2177ff9ef26feb3c155dfecc350b1a8ef" {
+		t.Errorf("Current failed to detect Hg on ref of branch. Got version: %s", v)
 	}
 
 	// Use Date to verify we are on the right commit.
@@ -109,8 +125,8 @@ func TestHg(t *testing.T) {
 	}
 
 	v, err = repo.Version()
-	if v != "9c6ccbca73e8" {
-		t.Error("Error checking checked out Hg version")
+	if v != "9c6ccbca73e8a1351c834f33f57f1f7a0329ad35" {
+		t.Errorf("Error checking checked out Hg version: %s", v)
 	}
 	if err != nil {
 		t.Error(err)

--- a/repo.go
+++ b/repo.go
@@ -92,6 +92,12 @@ type Repo interface {
 	// Version retrieves the current version.
 	Version() (string, error)
 
+	// Current retrieves the current version-ish. This is different from the
+	// Version method. The output could be a branch name if on the tip of a
+	// branch (git), a tag if on a tag, a revision if on a specific revision
+	// that's not the tip of the branch. The values here vary based on the VCS.
+	Current() (string, error)
+
 	// Date retrieves the date on the latest commit.
 	Date() (time.Time, error)
 

--- a/svn.go
+++ b/svn.go
@@ -126,12 +126,43 @@ func (s *SvnRepo) UpdateVersion(version string) error {
 
 // Version retrieves the current version.
 func (s *SvnRepo) Version() (string, error) {
-	out, err := s.RunFromDir("svnversion", ".")
+	type Commit struct {
+		Revision string `xml:"revision,attr"`
+	}
+	type Info struct {
+		Commit Commit `xml:"entry>commit"`
+	}
+
+	out, err := s.RunFromDir("svn", "info", "--xml")
 	s.log(out)
+	infos := &Info{}
+	err = xml.Unmarshal(out, &infos)
 	if err != nil {
 		return "", NewLocalError("Unable to retrieve checked out version", err, string(out))
 	}
-	return strings.TrimSpace(string(out)), nil
+
+	return infos.Commit.Revision, nil
+}
+
+// Current returns the current version-ish. This means:
+// * HEAD if on the tip.
+// * Otherwise a revision id
+func (s *SvnRepo) Current() (string, error) {
+	tip, err := s.CommitInfo("HEAD")
+	if err != nil {
+		return "", err
+	}
+
+	curr, err := s.Version()
+	if err != nil {
+		return "", err
+	}
+
+	if tip.Commit == curr {
+		return "HEAD", nil
+	}
+
+	return curr, nil
 }
 
 // Date retrieves the date on the latest commit.
@@ -209,6 +240,31 @@ func (s *SvnRepo) IsDirty() bool {
 
 // CommitInfo retrieves metadata about a commit.
 func (s *SvnRepo) CommitInfo(id string) (*CommitInfo, error) {
+
+	// There are cases where Svn log doesn't return anything for HEAD or BASE.
+	// svn info does provide details for these but does not have elements like
+	// the commit message.
+	if id == "HEAD" || id == "BASE" {
+		type Commit struct {
+			Revision string `xml:"revision,attr"`
+		}
+		type Info struct {
+			Commit Commit `xml:"entry>commit"`
+		}
+
+		out, err := s.RunFromDir("svn", "info", "-r", id, "--xml")
+		infos := &Info{}
+		err = xml.Unmarshal(out, &infos)
+		if err != nil {
+			return nil, NewLocalError("Unable to retrieve commit information", err, string(out))
+		}
+
+		id = infos.Commit.Revision
+		if id == "" {
+			return nil, ErrRevisionUnavailable
+		}
+	}
+
 	out, err := s.RunFromDir("svn", "log", "-r", id, "--xml")
 	if err != nil {
 		return nil, NewRemoteError("Unable to retrieve commit information", err, string(out))

--- a/svn_test.go
+++ b/svn_test.go
@@ -87,6 +87,14 @@ func TestSvn(t *testing.T) {
 	// 	t.Error("Wrong version returned from NewRepo")
 	// }
 
+	v, err := repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Svn Current: %s", err)
+	}
+	if v != "HEAD" {
+		t.Errorf("Current failed to detect Svn on HEAD. Got version: %s", v)
+	}
+
 	// Update the version to a previous version.
 	err = repo.UpdateVersion("r2")
 	if err != nil {
@@ -94,12 +102,20 @@ func TestSvn(t *testing.T) {
 	}
 
 	// Use Version to verify we are on the right version.
-	v, err := repo.Version()
+	v, err = repo.Version()
 	if v != "2" {
 		t.Error("Error checking checked SVN out version")
 	}
 	if err != nil {
 		t.Error(err)
+	}
+
+	v, err = repo.Current()
+	if err != nil {
+		t.Errorf("Error trying Svn Current for ref: %s", err)
+	}
+	if v != "2" {
+		t.Errorf("Current failed to detect Svn on HEAD. Got version: %s", v)
 	}
 
 	// Perform an update which should take up back to the latest version.


### PR DESCRIPTION
Includes:
- Fix to SVN versions. There were times an incorrect version would
  be returned.
- Hg now using full hash for versions as it should have been. This
  fixes a bug.