### PR TITLE
Flexible exec

### DIFF
--- a/bzr.go
+++ b/bzr.go
@@ -65,8 +65,8 @@ func (s BzrRepo) Vcs() Type {
 }
 
 // GetCmd returns the command to clone a bazaar repo.
-func (s *BzrRepo) GetCmd() (string, []string) {
-	return "bzr", []string{"branch", s.Remote(), s.LocalPath()}
+func (s *BzrRepo) GetCmd() *exec.Cmd {
+	return exec.Command("bzr", "branch", s.Remote(), s.LocalPath())
 }
 
 // Get is used to perform an initial clone of a repository.
@@ -75,8 +75,7 @@ func (s *BzrRepo) Get() error {
 		return err
 	}
 
-	name, args := s.GetCmd()
-	out, err := s.run(name, args...)
+	out, err := s.runCommand(s.GetCmd())
 	if err != nil {
 		return NewRemoteError("Unable to get repository", err, string(out))
 	}
@@ -85,8 +84,8 @@ func (s *BzrRepo) Get() error {
 }
 
 // InitCmd returns the command to create a new bazaar repo.
-func (s *BzrRepo) InitCmd() (string, []string) {
-	return "bzr", []string{"init", s.LocalPath()}
+func (s *BzrRepo) InitCmd() *exec.Cmd {
+	return exec.Command("bzr", "init", s.LocalPath())
 }
 
 // Init initializes a bazaar repository at local location.
@@ -95,8 +94,7 @@ func (s *BzrRepo) Init() error {
 		return err
 	}
 
-	name, args := s.InitCmd()
-	out, err := s.run(name, args...)
+	out, err := s.runCommand(s.InitCmd())
 	if err != nil {
 		return NewLocalError("Unable to initialize repository", err, string(out))
 	}
@@ -105,14 +103,13 @@ func (s *BzrRepo) Init() error {
 }
 
 // UpdateCmd returns command to update bazaar repo.
-func (s *BzrRepo) UpdateCmd() (string, []string) {
-	return "bzr", []string{"pull"}
+func (s *BzrRepo) UpdateCmd() *exec.Cmd {
+	return exec.Command("bzr", "pull")
 }
 
 // Update performs a Bzr pull and update to an existing checkout.
 func (s *BzrRepo) Update() error {
-	name, args := s.UpdateCmd()
-	out, err := s.RunFromDir(name, args...)
+	out, err := s.RunCommandFromDir(s.UpdateCmd())
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))
 	}

--- a/bzr.go
+++ b/bzr.go
@@ -130,7 +130,7 @@ func (s *BzrRepo) UpdateCmd() (string, []string) {
 // Update performs a Bzr pull and update to an existing checkout.
 func (s *BzrRepo) Update() error {
 	name, args := s.UpdateCmd()
-	out, err := s.run(name, args...)
+	out, err := s.RunFromDir(name, args...)
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))
 	}

--- a/bzr.go
+++ b/bzr.go
@@ -64,6 +64,7 @@ func (s BzrRepo) Vcs() Type {
 	return Bzr
 }
 
+// GetCmd returns the command to clone a bazaar repo.
 func (s *BzrRepo) GetCmd() (string, []string) {
 	return "bzr", []string{"branch", s.Remote(), s.LocalPath()}
 }
@@ -83,6 +84,7 @@ func (s *BzrRepo) Get() error {
 	return nil
 }
 
+// InitCmd returns the command to create a new bazaar repo.
 func (s *BzrRepo) InitCmd() (string, []string) {
 	return "bzr", []string{"init", s.LocalPath()}
 }
@@ -102,6 +104,7 @@ func (s *BzrRepo) Init() error {
 	return nil
 }
 
+// UpdateCmd returns command to update bazaar repo.
 func (s *BzrRepo) UpdateCmd() (string, []string) {
 	return "bzr", []string{"pull"}
 }

--- a/bzr.go
+++ b/bzr.go
@@ -109,7 +109,7 @@ func (s *BzrRepo) UpdateCmd() *exec.Cmd {
 
 // Update performs a Bzr pull and update to an existing checkout.
 func (s *BzrRepo) Update() error {
-	out, err := s.RunCommandFromDir(s.UpdateCmd())
+	out, err := s.RunCmdFromDir(s.UpdateCmd())
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))
 	}

--- a/bzr.go
+++ b/bzr.go
@@ -65,9 +65,12 @@ func (s BzrRepo) Vcs() Type {
 	return Bzr
 }
 
+func (s *BzrRepo) GetCmd() (string, []string) {
+	return "bzr", []string{"branch", s.Remote(), s.LocalPath()}
+}
+
 // Get is used to perform an initial clone of a repository.
 func (s *BzrRepo) Get() error {
-
 	basePath := filepath.Dir(filepath.FromSlash(s.LocalPath()))
 	if _, err := os.Stat(basePath); os.IsNotExist(err) {
 		err = os.MkdirAll(basePath, 0755)
@@ -76,7 +79,8 @@ func (s *BzrRepo) Get() error {
 		}
 	}
 
-	out, err := s.run("bzr", "branch", s.Remote(), s.LocalPath())
+	name, args := s.GetCmd()
+	out, err := s.run(name, args...)
 	if err != nil {
 		return NewRemoteError("Unable to get repository", err, string(out))
 	}
@@ -84,9 +88,14 @@ func (s *BzrRepo) Get() error {
 	return nil
 }
 
+func (s *BzrRepo) InitCmd() (string, []string) {
+	return "bzr", []string{"init", s.LocalPath()}
+}
+
 // Init initializes a bazaar repository at local location.
 func (s *BzrRepo) Init() error {
-	out, err := s.run("bzr", "init", s.LocalPath())
+	name, args := s.InitCmd()
+	out, err := s.run(name, args...)
 
 	// There are some windows cases where bazaar cannot create the parent
 	// directory if it does not already exist, to the location it's trying
@@ -114,9 +123,14 @@ func (s *BzrRepo) Init() error {
 	return nil
 }
 
+func (s *BzrRepo) UpdateCmd() (string, []string) {
+	return "bzr", []string{"pull"}
+}
+
 // Update performs a Bzr pull and update to an existing checkout.
 func (s *BzrRepo) Update() error {
-	out, err := s.RunFromDir("bzr", "pull")
+	name, args := s.UpdateCmd()
+	out, err := s.run(name, args...)
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))
 	}

--- a/git.go
+++ b/git.go
@@ -64,6 +64,7 @@ func (s GitRepo) Vcs() Type {
 	return Git
 }
 
+// GetCmd will clone git repo
 func (s *GitRepo) GetCmd() (string, []string) {
 	return "git", []string{"clone", s.Remote(), s.LocalPath()}
 }
@@ -82,6 +83,7 @@ func (s *GitRepo) Get() error {
 	return err
 }
 
+// InitCmd will return command to git init a new repo.
 func (s *GitRepo) InitCmd() (string, []string) {
 	return "git", []string{"init", s.LocalPath()}
 }
@@ -101,10 +103,12 @@ func (s *GitRepo) Init() error {
 	return nil
 }
 
+// FetchCmd will return command to fetch repo.
 func (s *GitRepo) FetchCmd() (string, []string) {
 	return "git", []string{"fetch", s.RemoteLocation}
 }
 
+// UpdateCmd will return command to pull changes for repo.
 func (s *GitRepo) UpdateCmd() (string, []string) {
 	return "git", []string{"pull"}
 }
@@ -115,13 +119,11 @@ func (s *GitRepo) Update() error {
 	cmd, args := s.FetchCmd()
 	out, err := s.RunFromDir(cmd, args...)
 
-	err = s.FetchError(out, err)
-	if err != nil {
+	if err = s.FetchError(out, err); err != nil {
 		if strings.Contains(err.Error(), "In detached head state, do not pull") {
 			return nil
-		} else {
-			return err
 		}
+		return err
 	}
 	cmd, args = s.UpdateCmd()
 	out, err = s.RunFromDir(cmd, args...)
@@ -132,6 +134,8 @@ func (s *GitRepo) Update() error {
 	return nil
 }
 
+// FetchError will pass through the error response of FetchCmd and handle
+// the case where the repo may be inside an "detached head" state.
 func (s *GitRepo) FetchError(out []byte, err error) error {
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))

--- a/git.go
+++ b/git.go
@@ -113,7 +113,7 @@ func (s *GitRepo) UpdateCmd() *exec.Cmd {
 // Update performs an Git fetch and pull to an existing checkout.
 func (s *GitRepo) Update() error {
 	// Perform a fetch to make sure everything is up to date.
-	out, err := s.RunCommandFromDir(s.FetchCmd())
+	out, err := s.RunCmdFromDir(s.FetchCmd())
 
 	if err = s.FetchError(out, err); err != nil {
 		if strings.Contains(err.Error(), "In detached head state, do not pull") {
@@ -122,7 +122,7 @@ func (s *GitRepo) Update() error {
 		return err
 	}
 
-	out, err = s.RunCommandFromDir(s.UpdateCmd())
+	out, err = s.RunCmdFromDir(s.UpdateCmd())
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))
 	}

--- a/git.go
+++ b/git.go
@@ -155,9 +155,14 @@ func (s *GitRepo) Update() error {
 	// Perform a fetch to make sure everything is up to date.
 	cmd, args := s.FetchCmd()
 	out, err := s.RunFromDir(cmd, args...)
+
 	err = s.FetchError(out, err)
-	if strings.Contains(err.Error(), "In detached head state, do not pull") {
-		return nil
+	if err != nil {
+		if strings.Contains(err.Error(), "In detached head state, do not pull") {
+			return nil
+		} else {
+			return err
+		}
 	}
 	cmd, args = s.UpdateCmd()
 	out, err = s.RunFromDir(cmd, args...)

--- a/hg.go
+++ b/hg.go
@@ -65,14 +65,13 @@ func (s HgRepo) Vcs() Type {
 }
 
 // GetCmd returns command to clone hg repo.
-func (s *HgRepo) GetCmd() (string, []string) {
-	return "hg", []string{"clone", s.Remote(), s.LocalPath()}
+func (s *HgRepo) GetCmd() *exec.Cmd {
+	return exec.Command("hg", "clone", s.Remote(), s.LocalPath())
 }
 
 // Get is used to perform an initial clone of a repository.
 func (s *HgRepo) Get() error {
-	name, args := s.GetCmd()
-	out, err := s.run(name, args...)
+	out, err := s.runCommand(s.GetCmd())
 	if err != nil {
 		return NewRemoteError("Unable to get repository", err, string(out))
 	}
@@ -80,14 +79,13 @@ func (s *HgRepo) Get() error {
 }
 
 // InitCmd returns command to init hg repo
-func (s *HgRepo) InitCmd() (string, []string) {
-	return "hg", []string{"init", s.LocalPath()}
+func (s *HgRepo) InitCmd() *exec.Cmd {
+	return exec.Command("hg", "init", s.LocalPath())
 }
 
 // Init will initialize a mercurial repository at local location.
 func (s *HgRepo) Init() error {
-	name, args := s.InitCmd()
-	out, err := s.run(name, args...)
+	out, err := s.runCommand(s.InitCmd())
 
 	if err != nil {
 		return NewLocalError("Unable to initialize repository", err, string(out))
@@ -96,14 +94,13 @@ func (s *HgRepo) Init() error {
 }
 
 // UpdateCmd returns command to update an hg repo.
-func (s *HgRepo) UpdateCmd() (string, []string) {
-	return "hg", []string{"update"}
+func (s *HgRepo) UpdateCmd() *exec.Cmd {
+	return exec.Command("hg", "update")
 }
 
 // Update performs a Mercurial pull to an existing checkout.
 func (s *HgRepo) Update() error {
-	name, args := s.UpdateCmd()
-	out, err := s.RunFromDir(name, args...)
+	out, err := s.RunCommandFromDir(s.UpdateCmd())
 
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))

--- a/hg.go
+++ b/hg.go
@@ -82,28 +82,38 @@ func (s *HgRepo) InitCmd() (string, []string) {
 	return "hg", []string{"init", s.LocalPath()}
 }
 
+func (s *HgRepo) InitError(out []byte, err error) error {
+	if err != nil {
+		return NewLocalError("Unable to initialize repository", err, string(out))
+	}
+	return err
+}
+
 // Init will initialize a mercurial repository at local location.
 func (s *HgRepo) Init() error {
 	name, args := s.InitCmd()
 	out, err := s.run(name, args...)
-	if err != nil {
-		return NewLocalError("Unable to initialize repository", err, string(out))
-	}
-	return nil
+
+	return s.InitError(out, err)
 }
 
 func (s *HgRepo) UpdateCmd() (string, []string) {
 	return "hg", []string{"update"}
 }
 
-// Update performs a Mercurial pull to an existing checkout.
-func (s *HgRepo) Update() error {
-	name, args := s.UpdateCmd()
-	out, err := s.run(name, args...)
+func (s *HgRepo) UpdateError(out []byte, err error) error {
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))
 	}
-	return nil
+	return err
+}
+
+// Update performs a Mercurial pull to an existing checkout.
+func (s *HgRepo) Update() error {
+	name, args := s.UpdateCmd()
+	out, err := s.RunFromDir(name, args...)
+
+	return s.UpdateError(out, err)
 }
 
 // UpdateVersion sets the version of a package currently checked out via Hg.

--- a/hg.go
+++ b/hg.go
@@ -64,6 +64,7 @@ func (s HgRepo) Vcs() Type {
 	return Hg
 }
 
+// GetCmd returns command to clone hg repo.
 func (s *HgRepo) GetCmd() (string, []string) {
 	return "hg", []string{"clone", s.Remote(), s.LocalPath()}
 }
@@ -78,6 +79,7 @@ func (s *HgRepo) Get() error {
 	return nil
 }
 
+// InitCmd returns command to init hg repo
 func (s *HgRepo) InitCmd() (string, []string) {
 	return "hg", []string{"init", s.LocalPath()}
 }
@@ -93,6 +95,7 @@ func (s *HgRepo) Init() error {
 	return err
 }
 
+// UpdateCmd returns command to update an hg repo.
 func (s *HgRepo) UpdateCmd() (string, []string) {
 	return "hg", []string{"update"}
 }

--- a/hg.go
+++ b/hg.go
@@ -82,30 +82,19 @@ func (s *HgRepo) InitCmd() (string, []string) {
 	return "hg", []string{"init", s.LocalPath()}
 }
 
-func (s *HgRepo) InitError(out []byte, err error) error {
+// Init will initialize a mercurial repository at local location.
+func (s *HgRepo) Init() error {
+	name, args := s.InitCmd()
+	out, err := s.run(name, args...)
+
 	if err != nil {
 		return NewLocalError("Unable to initialize repository", err, string(out))
 	}
 	return err
 }
 
-// Init will initialize a mercurial repository at local location.
-func (s *HgRepo) Init() error {
-	name, args := s.InitCmd()
-	out, err := s.run(name, args...)
-
-	return s.InitError(out, err)
-}
-
 func (s *HgRepo) UpdateCmd() (string, []string) {
 	return "hg", []string{"update"}
-}
-
-func (s *HgRepo) UpdateError(out []byte, err error) error {
-	if err != nil {
-		return NewRemoteError("Unable to update repository", err, string(out))
-	}
-	return err
 }
 
 // Update performs a Mercurial pull to an existing checkout.
@@ -113,7 +102,10 @@ func (s *HgRepo) Update() error {
 	name, args := s.UpdateCmd()
 	out, err := s.RunFromDir(name, args...)
 
-	return s.UpdateError(out, err)
+	if err != nil {
+		return NewRemoteError("Unable to update repository", err, string(out))
+	}
+	return err
 }
 
 // UpdateVersion sets the version of a package currently checked out via Hg.

--- a/hg.go
+++ b/hg.go
@@ -64,27 +64,42 @@ func (s HgRepo) Vcs() Type {
 	return Hg
 }
 
+func (s *HgRepo) GetCmd() (string, []string) {
+	return "hg", []string{"clone", s.Remote(), s.LocalPath()}
+}
+
 // Get is used to perform an initial clone of a repository.
 func (s *HgRepo) Get() error {
-	out, err := s.run("hg", "clone", s.Remote(), s.LocalPath())
+	name, args := s.GetCmd()
+	out, err := s.run(name, args...)
 	if err != nil {
 		return NewRemoteError("Unable to get repository", err, string(out))
 	}
 	return nil
 }
 
+func (s *HgRepo) InitCmd() (string, []string) {
+	return "hg", []string{"init", s.LocalPath()}
+}
+
 // Init will initialize a mercurial repository at local location.
 func (s *HgRepo) Init() error {
-	out, err := s.run("hg", "init", s.LocalPath())
+	name, args := s.InitCmd()
+	out, err := s.run(name, args...)
 	if err != nil {
 		return NewLocalError("Unable to initialize repository", err, string(out))
 	}
 	return nil
 }
 
+func (s *HgRepo) UpdateCmd() (string, []string) {
+	return "hg", []string{"update"}
+}
+
 // Update performs a Mercurial pull to an existing checkout.
 func (s *HgRepo) Update() error {
-	out, err := s.RunFromDir("hg", "update")
+	name, args := s.UpdateCmd()
+	out, err := s.run(name, args...)
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))
 	}

--- a/hg.go
+++ b/hg.go
@@ -100,7 +100,7 @@ func (s *HgRepo) UpdateCmd() *exec.Cmd {
 
 // Update performs a Mercurial pull to an existing checkout.
 func (s *HgRepo) Update() error {
-	out, err := s.RunCommandFromDir(s.UpdateCmd())
+	out, err := s.RunCmdFromDir(s.UpdateCmd())
 
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))

--- a/repo.go
+++ b/repo.go
@@ -80,11 +80,20 @@ type Repo interface {
 	// Get is used to perform an initial clone/checkout of a repository.
 	Get() error
 
+	// GetCmd retrieves the arguments for the GetCommand
+	GetCmd() (string, []string)
+
 	// Initializes a new repository locally.
 	Init() error
 
+	// InitCmd retrieves the command to initialize repo.
+	InitCmd() (string, []string)
+
 	// Update performs an update to an existing checkout of a repository.
 	Update() error
+
+	// UpdateCmd returns command to update repo
+	UpdateCmd() (string, []string)
 
 	// UpdateVersion sets the version of a package of a repository.
 	UpdateVersion(string) error
@@ -209,6 +218,15 @@ func (b *base) setRemote(remote string) {
 
 func (b *base) setLocalPath(local string) {
 	b.local = local
+}
+
+func (b base) command(cmd string, args ...string) ([]byte, error) {
+	out, err := exec.Command(cmd, args...).CombinedOutput()
+	b.log(out)
+	if err != nil {
+		err = fmt.Errorf("%s: %s", out, err)
+	}
+	return out, err
 }
 
 func (b base) run(cmd string, args ...string) ([]byte, error) {

--- a/repo.go
+++ b/repo.go
@@ -221,15 +221,6 @@ func (b *base) setLocalPath(local string) {
 	b.local = local
 }
 
-func (b base) command(cmd string, args ...string) ([]byte, error) {
-	out, err := exec.Command(cmd, args...).CombinedOutput()
-	b.log(out)
-	if err != nil {
-		err = fmt.Errorf("%s: %s", out, err)
-	}
-	return out, err
-}
-
 func (b base) run(cmd string, args ...string) ([]byte, error) {
 	out, err := exec.Command(cmd, args...).CombinedOutput()
 	b.log(out)

--- a/repo.go
+++ b/repo.go
@@ -31,6 +31,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -254,6 +255,20 @@ func (b *base) referenceList(c, r string) []string {
 	}
 
 	return out
+}
+
+// EnsureParentDir checks if parent dir exists, if not, creates dirs
+// recursively up to and including the parent dir.
+// There are some windows cases where Git cannot create the parent directory,
+func (b *base) EnsureParentDir() error {
+	basePath := filepath.Dir(filepath.FromSlash(b.LocalPath()))
+	if _, err := os.Stat(basePath); os.IsNotExist(err) {
+		err = os.MkdirAll(basePath, 0755)
+		if err != nil {
+			return NewLocalError("Unable to create directory", err, "")
+		}
+	}
+	return nil
 }
 
 func envForDir(dir string) []string {

--- a/repo.go
+++ b/repo.go
@@ -230,6 +230,7 @@ func (b base) run(cmd string, args ...string) ([]byte, error) {
 	return out, err
 }
 
+// Run a command from repo's local path
 func (b *base) RunFromDir(cmd string, args ...string) ([]byte, error) {
 	c := exec.Command(cmd, args...)
 	c.Dir = b.local
@@ -249,8 +250,8 @@ func (b *base) referenceList(c, r string) []string {
 }
 
 // EnsureParentDir checks if parent dir exists, if not, creates dirs
-// recursively up to and including the parent dir.
-// There are some windows cases where Git cannot create the parent directory,
+// recursively up to and including the parent dir. Most VCS will *not*
+// do this for you, and instead show an error.
 func (b *base) EnsureParentDir() error {
 	basePath := filepath.Dir(filepath.FromSlash(b.LocalPath()))
 	if _, err := os.Stat(basePath); os.IsNotExist(err) {

--- a/repo.go
+++ b/repo.go
@@ -239,13 +239,13 @@ func (b base) runCommand(cmd *exec.Cmd) ([]byte, error) {
 
 // Run a command from repo's local path
 func (b *base) RunFromDir(cmd string, args ...string) ([]byte, error) {
-	out, errc := b.RunCommandFromDir(exec.Command(cmd, args...))
+	out, errc := b.RunCmdFromDir(exec.Command(cmd, args...))
 
 	return out, errc
 }
 
 // Run a command from directory
-func (b *base) RunCommandFromDir(c *exec.Cmd) ([]byte, error) {
+func (b *base) RunCmdFromDir(c *exec.Cmd) ([]byte, error) {
 	c.Dir = b.local
 	c.Env = envForDir(c.Dir)
 	out, err := c.CombinedOutput()

--- a/svn.go
+++ b/svn.go
@@ -63,6 +63,7 @@ func (s SvnRepo) Vcs() Type {
 	return Svn
 }
 
+// GetCmd returns command to checkout svn repo.
 func (s *SvnRepo) GetCmd() (string, []string) {
 	remote := s.Remote()
 	if strings.HasPrefix(remote, "/") {
@@ -84,6 +85,7 @@ func (s *SvnRepo) Get() error {
 	return nil
 }
 
+// InitCmd returns command to create svn repo via svnadmin(1).
 func (s *SvnRepo) InitCmd() (string, []string) {
 	return "svnadmin", []string{"create", s.Remote()}
 }
@@ -101,6 +103,7 @@ func (s *SvnRepo) Init() error {
 	return nil
 }
 
+// UpdateCmd returns command to update svn repo.
 func (s *SvnRepo) UpdateCmd() (string, []string) {
 	return "svn", []string{"update"}
 }

--- a/svn.go
+++ b/svn.go
@@ -108,7 +108,7 @@ func (s *SvnRepo) UpdateCmd() *exec.Cmd {
 
 // Update performs an SVN update to an existing checkout.
 func (s *SvnRepo) Update() error {
-	out, err := s.RunCommandFromDir(s.UpdateCmd())
+	out, err := s.RunCmdFromDir(s.UpdateCmd())
 
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))

--- a/svn.go
+++ b/svn.go
@@ -85,7 +85,7 @@ func (s *SvnRepo) Get() error {
 }
 
 func (s *SvnRepo) InitCmd() (string, []string) {
-	return "svn", []string{"svnadmin", "create", s.Remote()}
+	return "svnadmin", []string{"create", s.Remote()}
 }
 
 // Init will create a svn repository at remote location.

--- a/svn.go
+++ b/svn.go
@@ -64,20 +64,19 @@ func (s SvnRepo) Vcs() Type {
 }
 
 // GetCmd returns command to checkout svn repo.
-func (s *SvnRepo) GetCmd() (string, []string) {
+func (s *SvnRepo) GetCmd() *exec.Cmd {
 	remote := s.Remote()
 	if strings.HasPrefix(remote, "/") {
 		remote = "file://" + remote
 	}
-	return "svn", []string{"checkout", remote, s.LocalPath()}
+	return exec.Command("svn", "checkout", remote, s.LocalPath())
 }
 
 // Get is used to perform an initial checkout of a repository.
 // Note, because SVN isn't distributed this is a checkout without
 // a clone.
 func (s *SvnRepo) Get() error {
-	name, args := s.GetCmd()
-	out, err := s.run(name, args...)
+	out, err := s.runCommand(s.GetCmd())
 
 	if err != nil {
 		return NewRemoteError("Unable to get repository", err, string(out))
@@ -86,8 +85,8 @@ func (s *SvnRepo) Get() error {
 }
 
 // InitCmd returns command to create svn repo via svnadmin(1).
-func (s *SvnRepo) InitCmd() (string, []string) {
-	return "svnadmin", []string{"create", s.Remote()}
+func (s *SvnRepo) InitCmd() *exec.Cmd {
+	return exec.Command("svnadmin", "create", s.Remote())
 }
 
 // Init will create a svn repository at remote location.
@@ -95,8 +94,7 @@ func (s *SvnRepo) Init() error {
 	if err := s.EnsureParentDir(); err != nil {
 		return err
 	}
-	name, args := s.InitCmd()
-	out, err := s.run(name, args...)
+	out, err := s.runCommand(s.InitCmd())
 	if err != nil {
 		return NewLocalError("Unable to initialize repository", err, string(out))
 	}
@@ -104,14 +102,13 @@ func (s *SvnRepo) Init() error {
 }
 
 // UpdateCmd returns command to update svn repo.
-func (s *SvnRepo) UpdateCmd() (string, []string) {
-	return "svn", []string{"update"}
+func (s *SvnRepo) UpdateCmd() *exec.Cmd {
+	return exec.Command("svn", "update")
 }
 
 // Update performs an SVN update to an existing checkout.
 func (s *SvnRepo) Update() error {
-	cmd, args := s.UpdateCmd()
-	out, err := s.RunFromDir(cmd, args...)
+	out, err := s.RunCommandFromDir(s.UpdateCmd())
 
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))


### PR DESCRIPTION
Fixes #39 
- decouples commands from `base.Get`, `base.Init`, `base.Update` into `GetCmd`, `InitCmd`, `UpdateCmd` to return standard library's `*exec.Cmd`. This gives downstream users the flexibility to access repo commands as they choose.
- Current behavior of `base.Get`, `base.Init` and `base.Update` are method is preserved.
- Two new methods, `base.runCmd` and `base.RunCmdFromDir` accept standard library `*exec.Cmd` as arguments. `base.run` and `base.RunFromDir`  behave the same to preserve compatibility downstream.
- A lot of redundant code has around parent directories being being created has been moved to `EnsureParentDir()`.  This reduces the complexity inside of `Init` and `Get` methods.
