### PR TITLE
Fixed hg's update method so that it pulls from remote before updates

### DIFF
--- a/hg.go
+++ b/hg.go
@@ -84,11 +84,7 @@ func (s *HgRepo) Init() error {
 
 // Update performs a Mercurial pull to an existing checkout.
 func (s *HgRepo) Update() error {
-	out, err := s.RunFromDir("hg", "update")
-	if err != nil {
-		return NewRemoteError("Unable to update repository", err, string(out))
-	}
-	return nil
+	return s.UpdateVersion(``)
 }
 
 // UpdateVersion sets the version of a package currently checked out via Hg.
@@ -97,7 +93,11 @@ func (s *HgRepo) UpdateVersion(version string) error {
 	if err != nil {
 		return NewLocalError("Unable to update checked out version", err, string(out))
 	}
-	out, err = s.RunFromDir("hg", "update", version)
+	if len(strings.TrimSpace(version)) > 0 {
+		out, err = s.RunFromDir("hg", "update", version)
+	} else {
+		out, err = s.RunFromDir("hg", "update")
+	}
 	if err != nil {
 		return NewLocalError("Unable to update checked out version", err, string(out))
 	}


### PR DESCRIPTION
Hi there! I got here from glide. We use bitbucket hg repos for our go projects.

When a project dependency gets updated in the remote repo we then update the version glide.yaml and run `glide up` but it throws an error saying unknown version.

I checked the code and it turned out that only in case of hg the Update() method executes only `hg update` which does not fetch changes from the remote repo, it only updates the version to the latest known locally.