### PR TITLE
Change SVN CheckLocal() to assume it may not be in the working copy root

### DIFF
--- a/svn.go
+++ b/svn.go
@@ -2,6 +2,7 @@ package vcs
 
 import (
 	"encoding/xml"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -185,12 +186,15 @@ func (s *SvnRepo) Date() (time.Time, error) {
 
 // CheckLocal verifies the local location is an SVN repo.
 func (s *SvnRepo) CheckLocal() bool {
-	if _, err := os.Stat(s.LocalPath() + "/.svn"); err == nil {
-		return true
+	sep := fmt.Sprintf("%c", os.PathSeparator)
+	psplit := strings.Split(s.LocalPath(), sep)
+	for i := 0; i < len(psplit); i++ {
+		path := fmt.Sprintf("%s%s", sep, filepath.Join(psplit[0:(len(psplit)-(i+1))]...))
+		if _, err := os.Stat(filepath.Join(path, ".svn")); err == nil {
+			return true
+		}
 	}
-
 	return false
-
 }
 
 // Tags returns []string{} as there are no formal tags in SVN. Tags are a

--- a/svn.go
+++ b/svn.go
@@ -189,7 +189,7 @@ func (s *SvnRepo) CheckLocal() bool {
 	sep := fmt.Sprintf("%c", os.PathSeparator)
 	psplit := strings.Split(s.LocalPath(), sep)
 	for i := 0; i < len(psplit); i++ {
-		path := fmt.Sprintf("%s%s", sep, filepath.Join(psplit[0:(len(psplit)-(i+1))]...))
+		path := fmt.Sprintf("%s%s", sep, filepath.Join(psplit[0:(len(psplit)-(i))]...))
 		if _, err := os.Stat(filepath.Join(path, ".svn")); err == nil {
 			return true
 		}


### PR DESCRIPTION
I've modified the svn support to detect an SVN repo, even if you are not at the top level of it. This behavior is more in line with how the `svn` command works. Newer versions of SVN do not place `.svn` directories at every level, but walk the directory tree backwards until one is found at the top level of the repository. I also refactored the remote url detecting code to use, in my opinion, a more reliable method.