### PR TITLE
Git fetch *all* tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.8.1 (unreleased)
+
+- Fixed #53: Git not fetching tags off branch
+
 # 1.8.0 (2016-06-29)
 
 ## Added

--- a/git.go
+++ b/git.go
@@ -131,7 +131,7 @@ func (s *GitRepo) Init() error {
 // Update performs an Git fetch and pull to an existing checkout.
 func (s *GitRepo) Update() error {
 	// Perform a fetch to make sure everything is up to date.
-	out, err := s.RunFromDir("git", "fetch", s.RemoteLocation)
+	out, err := s.RunFromDir("git", "fetch --tags", s.RemoteLocation)
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))
 	}

--- a/git.go
+++ b/git.go
@@ -131,7 +131,7 @@ func (s *GitRepo) Init() error {
 // Update performs an Git fetch and pull to an existing checkout.
 func (s *GitRepo) Update() error {
 	// Perform a fetch to make sure everything is up to date.
-	out, err := s.RunFromDir("git", "fetch --tags", s.RemoteLocation)
+	out, err := s.RunFromDir("git", "fetch", "--tags", s.RemoteLocation)
 	if err != nil {
 		return NewRemoteError("Unable to update repository", err, string(out))
 	}


### PR DESCRIPTION
We have some customers experiencing this - currently we're telling them to `glide cc` before running `glide up`, but that is expensive and causing people to lose faith in Glide all-together.

Fixes #53 

@mattfarina any tips on testing this? The current tests for this repo don' t seem to illustrate how to set up the world for a given scenario.