### PR TITLE
Defend against the waking nightmare that is git submodules

### DIFF
--- a/git.go
+++ b/git.go
@@ -384,6 +384,12 @@ func (s *GitRepo) ExportDir(dir string) error {
 	if err != nil {
 		return NewLocalError("Unable to export source", err, string(out))
 	}
+	// and now, the horror of submodules
+	out, err := s.RunFromDir("git", "submodule", "foreach", "--recursive", "'git checkout-index -f -a --prefix=\""+filepath.Join(dir, "$path")+"\"'")
+	s.log(out)
+	if err != nil {
+		return NewLocalError("Error while exporting submodule sources")
+	}
 
 	return nil
 }

--- a/git.go
+++ b/git.go
@@ -180,7 +180,7 @@ func (s *GitRepo) defendAgainstSubmodules() error {
 		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict submodule directories", err, string(out))
 	}
 	// Then, repeat just in case there are any nested submodules that went away.
-	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "clean", "-x", "-d", "-f", "-f")
+	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git", "clean", "-x", "-d", "-f", "-f")
 	if err != nil {
 		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict nested submodule directories", err, string(out))
 	}

--- a/git.go
+++ b/git.go
@@ -168,8 +168,8 @@ func (s *GitRepo) UpdateVersion(version string) error {
 // defendAgainstSubmodules tries to keep repo state sane in the event of
 // submodules. Or nested submodules. What a great idea, submodules.
 func (s *GitRepo) defendAgainstSubmodules() error {
-	// First, update them to whatever they shoudl be, if there should happen to be any.
-	out, err = s.RunFromDir("git", "submodule", "update", "--init", "--recursive")
+	// First, update them to whatever they should be, if there should happen to be any.
+	out, err := s.RunFromDir("git", "submodule", "update", "--init", "--recursive")
 	if err != nil {
 		return NewLocalError("Unexpected error while defensively updating submodules", err, string(out))
 	}
@@ -177,12 +177,12 @@ func (s *GitRepo) defendAgainstSubmodules() error {
 	// one or more submodules to go away.
 	out, err = s.RunFromDir("git", "clean", "-x", "-d", "-f", "-f")
 	if err != nil {
-		return NewLocalError("Unexpected while defensively cleaning up after possible submodules", err, string(out))
+		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict submodule directories", err, string(out))
 	}
 	// Then, repeat just in case there are any nested submodules that went away.
 	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "clean", "-x", "-d", "-f", "-f")
 	if err != nil {
-		return NewLocalError("Unexpected while defensively cleaning up after possible submodules", err, string(out))
+		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict nested submodule directories", err, string(out))
 	}
 
 	return nil
@@ -385,10 +385,10 @@ func (s *GitRepo) ExportDir(dir string) error {
 		return NewLocalError("Unable to export source", err, string(out))
 	}
 	// and now, the horror of submodules
-	out, err := s.RunFromDir("git", "submodule", "foreach", "--recursive", "'git checkout-index -f -a --prefix=\""+filepath.Join(dir, "$path")+"\"'")
+	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "'git checkout-index -f -a --prefix=\""+filepath.Join(dir, "$path")+"\"'")
 	s.log(out)
 	if err != nil {
-		return NewLocalError("Error while exporting submodule sources")
+		return NewLocalError("Error while exporting submodule sources", err, string(out))
 	}
 
 	return nil

--- a/git.go
+++ b/git.go
@@ -70,7 +70,7 @@ func (s GitRepo) Vcs() Type {
 
 // Get is used to perform an initial clone of a repository.
 func (s *GitRepo) Get() error {
-	out, err := s.run("git", "clone", s.Remote(), s.LocalPath())
+	out, err := s.run("git", "clone", "--recursive", s.Remote(), s.LocalPath())
 
 	// There are some windows cases where Git cannot create the parent directory,
 	// if it does not already exist, to the location it's trying to create the


### PR DESCRIPTION
Seriously, this makes me want to die. But Masterminds/glide#698 is correct - we can't just ignore it.

I _think_ this covers it. Probably. Maybe. ugh. I'm just so super glad that every single checkout/pull will now have to run three additional commands afterwards in order to be safe.