### PR TITLE
git: remove extra quotes in submodule export

### DIFF
--- a/git.go
+++ b/git.go
@@ -385,7 +385,7 @@ func (s *GitRepo) ExportDir(dir string) error {
 		return NewLocalError("Unable to export source", err, string(out))
 	}
 	// and now, the horror of submodules
-	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "'git checkout-index -f -a --prefix=\""+filepath.Join(dir, "$path")+"\"'")
+	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git checkout-index -f -a --prefix=\""+filepath.Join(dir, "$path")+"/\"")
 	s.log(out)
 	if err != nil {
 		return NewLocalError("Error while exporting submodule sources", err, string(out))


### PR DESCRIPTION
on the cli, one uses the extra single quotes to ensure the whole cmd is passed as a single arg despite
containing spaces, but when passing args in a structured call like this, it isn't needed, and instead causes this error:
```
[ERROR]	Unable to export dependencies to vendor directory: Error while exporting submodule sources
[DEBUG]	Output was: Entering 'lightstep-tracer-common'
/.../git-submodule: line 428: git checkout-index -f -a --prefix="/.../vendor/github.com/lightstep/lightstep-tracer-go/$path": No such file or directory
Stopping at 'lightstep-tracer-common'; script returned non-zero status.
```

Fixes Masterminds/glide#745