### PR TITLE
Fatal error if bzr is not installed

### DIFF
--- a/bzr_test.go
+++ b/bzr_test.go
@@ -31,7 +31,7 @@ func TestBzr(t *testing.T) {
 
 	repo, err := NewBzrRepo("https://launchpad.net/govcstestbzrrepo", tempDir+"/govcstestbzrrepo")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if repo.Vcs() != Bzr {


### PR DESCRIPTION
If we get a "bzr not installed" error, the `repo` object is nil which
causes a NPE panic on the next line. Probably better just to Fatal
the test (which stops execution) instead of reporting a test failure
and then immediately panicking.