### PR TITLE
Glide-745: Add git submodule update

### DIFF
--- a/git.go
+++ b/git.go
@@ -384,7 +384,14 @@ func (s *GitRepo) ExportDir(dir string) error {
 	if err != nil {
 		return NewLocalError("Unable to export source", err, string(out))
 	}
+
 	// and now, the horror of submodules
+	out, err = s.RunFromDir("git", "submodule", "update", "--init", "--recursive" )
+	s.log(out)
+	if err != nil {
+		return NewLocalError("Error while updating submodule sources", err, string(out))
+	}
+
 	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git checkout-index -f -a --prefix=\""+filepath.Join(dir, "$path")+string(filepath.Separator)+"\"")
 	s.log(out)
 	if err != nil {


### PR DESCRIPTION
The "git submodule foreach --recursive git checkout-index ..." seems to be failing on Windows (and maybe elsewhere, too) because the submodules are not previously init'd -
this change seeks to fix that.