### PR TITLE
VCS-74: Add +build tags to tests, to enable selective per-VCS testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ setup:
 .PHONY: test
 test: validate lint
 	@echo "==> Running tests"
-	go test -v
+	go test -v -tags all
 
 .PHONY: validate
 validate:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,6 @@ build_script:
   - go install -v ./...
 
 test_script:
-  - go test -v
+  - go test -v -tags all
 
 deploy: off

--- a/bzr_test.go
+++ b/bzr_test.go
@@ -1,3 +1,5 @@
+// +build all bzr
+
 package vcs
 
 import (

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,3 +1,5 @@
+// +build all errors
+
 package vcs
 
 import (

--- a/git_test.go
+++ b/git_test.go
@@ -1,3 +1,5 @@
+// +build all git
+
 package vcs
 
 import (

--- a/hg_test.go
+++ b/hg_test.go
@@ -1,3 +1,5 @@
+// +build all hg
+
 package vcs
 
 import (

--- a/repo_test.go
+++ b/repo_test.go
@@ -1,3 +1,5 @@
+// +build all repo
+
 package vcs
 
 import (

--- a/svn_test.go
+++ b/svn_test.go
@@ -1,3 +1,5 @@
+// +build all svn
+
 package vcs
 
 import (

--- a/vcs_remote_lookup_test.go
+++ b/vcs_remote_lookup_test.go
@@ -1,3 +1,5 @@
+// +build all vcs_remote_lookup
+
 package vcs
 
 import (


### PR DESCRIPTION
Add Golang build constraints (build tags) to *_test.go, so one can run only the tests for the module being developed, instead of previous default of all.
Note that Makefile and appveyor.yml have been updated to run all tests, as before.
Note that running "git test" now does *nothing* by default - this is a change.

Syntax: Run all tests:
go test -tags all
Syntax: Run git tests:
go test -tags git
