### PR TITLE
VCS-76: Fix submodule handling for Windows

### DIFF
--- a/git.go
+++ b/git.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -363,8 +364,31 @@ func (s *GitRepo) Ping() bool {
 	return err == nil
 }
 
+// EscapePathSeparator escapes the path separator by replacing it with several.
+// Note: this is harmless on Unix, and needed on Windows.
+func EscapePathSeparator(path string) (string) {
+	//On Windows, triple all path separators.
+	//Needed to escape backslash(s) preceding doublequotes, 
+	//because of how Windows strings treats backslash+doublequote combo,
+	//and Go seems to be implicitly passing around a doublequoted string on Windows,
+	//so we cannnot use default string instead.
+	//See: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+	//e.g., C:\foo\bar\ -> C:\\\foo\\\bar\\\
+	//used with --prefix, like this: --prefix=C:\foo\bar\ -> --prefix=C:\\\foo\\\bar\\\
+	if ( `windows` == string(runtime.GOOS)) {
+		path = strings.Replace(path,
+			string(os.PathSeparator),
+			string(os.PathSeparator)+string(os.PathSeparator)+string(os.PathSeparator),
+			-1)
+			//string(os.PathSeparator)+string(os.PathSeparator)+string(os.PathSeparator)+string(os.PathSeparator),
+	}
+	return path
+}
+
 // ExportDir exports the current revision to the passed in directory.
 func (s *GitRepo) ExportDir(dir string) error {
+
+	var path string
 
 	// Without the trailing / there can be problems.
 	if !strings.HasSuffix(dir, string(os.PathSeparator)) {
@@ -379,14 +403,16 @@ func (s *GitRepo) ExportDir(dir string) error {
 		return NewLocalError("Unable to create directory", err, "")
 	}
 
-	out, err := s.RunFromDir("git", "checkout-index", "-f", "-a", "--prefix="+dir)
+	path = EscapePathSeparator( dir )
+	out, err := s.RunFromDir("git", "checkout-index", "-f", "-a", "--prefix="+path)
 	s.log(out)
 	if err != nil {
 		return NewLocalError("Unable to export source", err, string(out))
 	}
 
 	// and now, the horror of submodules
-	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git", "checkout-index", "-f", "-a", "--prefix="+filepath.Join(dir, "$path")+string(os.PathSeparator))
+	path = EscapePathSeparator( dir + "$path" + string(os.PathSeparator) )
+	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git checkout-index -f -a --prefix="+path)
 	s.log(out)
 	if err != nil {
 		return NewLocalError("Error while exporting submodule sources", err, string(out))

--- a/git.go
+++ b/git.go
@@ -369,17 +369,17 @@ func (s *GitRepo) Ping() bool {
 func EscapePathSeparator(path string) (string) {
 	switch runtime.GOOS {
 	case `windows`:
-		//On Windows, triple all path separators.
-		//Needed to escape backslash(s) preceding doublequotes,
-		//because of how Windows strings treats backslash+doublequote combo,
-		//and Go seems to be implicitly passing around a doublequoted string on Windows,
-		//so we cannnot use default string instead.
-		//See: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
-		//e.g., C:\foo\bar\ -> C:\\\foo\\\bar\\\
-		//used with --prefix, like this: --prefix=C:\foo\bar\ -> --prefix=C:\\\foo\\\bar\\\
+		// On Windows, triple all path separators.
+		// Needed to escape backslash(s) preceding doublequotes,
+		// because of how Windows strings treats backslash+doublequote combo,
+		// and Go seems to be implicitly passing around a doublequoted string on Windows,
+		// so we cannnot use default string instead.
+		// See: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+		// e.g., C:\foo\bar\ -> C:\\\foo\\\bar\\\
+		// used with --prefix, like this: --prefix=C:\foo\bar\ -> --prefix=C:\\\foo\\\bar\\\
 		return strings.Replace(path,
 			string(os.PathSeparator),
-			string(os.PathSeparator)+string(os.PathSeparator)+string(os.PathSeparator),
+			string(os.PathSeparator) + string(os.PathSeparator) + string(os.PathSeparator),
 			-1)
 	default:
 		return path

--- a/git.go
+++ b/git.go
@@ -384,8 +384,9 @@ func (s *GitRepo) ExportDir(dir string) error {
 	if err != nil {
 		return NewLocalError("Unable to export source", err, string(out))
 	}
+
 	// and now, the horror of submodules
-	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git checkout-index -f -a --prefix=\""+filepath.Join(dir, "$path")+string(filepath.Separator)+"\"")
+	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git", "checkout-index", "-f", "-a", "--prefix="+filepath.Join(dir, "$path")+string(os.PathSeparator))
 	s.log(out)
 	if err != nil {
 		return NewLocalError("Error while exporting submodule sources", err, string(out))

--- a/git.go
+++ b/git.go
@@ -370,7 +370,7 @@ func EscapePathSeparator(path string) (string) {
 	switch runtime.GOOS {
 	case `windows`:
 		//On Windows, triple all path separators.
-		//Needed to escape backslash(s) preceding doublequotes, 
+		//Needed to escape backslash(s) preceding doublequotes,
 		//because of how Windows strings treats backslash+doublequote combo,
 		//and Go seems to be implicitly passing around a doublequoted string on Windows,
 		//so we cannnot use default string instead.

--- a/git.go
+++ b/git.go
@@ -367,22 +367,23 @@ func (s *GitRepo) Ping() bool {
 // EscapePathSeparator escapes the path separator by replacing it with several.
 // Note: this is harmless on Unix, and needed on Windows.
 func EscapePathSeparator(path string) (string) {
-	//On Windows, triple all path separators.
-	//Needed to escape backslash(s) preceding doublequotes, 
-	//because of how Windows strings treats backslash+doublequote combo,
-	//and Go seems to be implicitly passing around a doublequoted string on Windows,
-	//so we cannnot use default string instead.
-	//See: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
-	//e.g., C:\foo\bar\ -> C:\\\foo\\\bar\\\
-	//used with --prefix, like this: --prefix=C:\foo\bar\ -> --prefix=C:\\\foo\\\bar\\\
-	if ( `windows` == string(runtime.GOOS)) {
-		path = strings.Replace(path,
+	switch runtime.GOOS {
+	case `windows`:
+		//On Windows, triple all path separators.
+		//Needed to escape backslash(s) preceding doublequotes, 
+		//because of how Windows strings treats backslash+doublequote combo,
+		//and Go seems to be implicitly passing around a doublequoted string on Windows,
+		//so we cannnot use default string instead.
+		//See: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+		//e.g., C:\foo\bar\ -> C:\\\foo\\\bar\\\
+		//used with --prefix, like this: --prefix=C:\foo\bar\ -> --prefix=C:\\\foo\\\bar\\\
+		return strings.Replace(path,
 			string(os.PathSeparator),
 			string(os.PathSeparator)+string(os.PathSeparator)+string(os.PathSeparator),
 			-1)
-			//string(os.PathSeparator)+string(os.PathSeparator)+string(os.PathSeparator)+string(os.PathSeparator),
+	default:
+		return path
 	}
-	return path
 }
 
 // ExportDir exports the current revision to the passed in directory.


### PR DESCRIPTION
Tracking down flakey submodule handling on Windows box, seen in Glide, issue 745, 749 -
Right now I am thinking the double quotes around the argument to prefix= are breaking things -
I tried adding similar double quotes to the RunFromDir() on line 382, and that broke things worse -
which led me to think the doubles quotes on line 389 are problem.
Note this seems to be platform-specific, and when I test from CLI on Windows and Linux, it *seems* mostly happy :/
Looking forward to reviewer feedback on this one.
Note this is blocking me using Glide on Windows right now.