### PR TITLE
Add recursive submodule setting for Git repositories

### DIFF
--- a/bzr.go
+++ b/bzr.go
@@ -64,6 +64,11 @@ type BzrRepo struct {
 	base
 }
 
+// SetRecursive is not used for bzr repositories.
+func (BzrRepo) SetRecursive(bool) {
+	// Do Nothing
+}
+
 // Vcs retrieves the underlying VCS being implemented.
 func (s BzrRepo) Vcs() Type {
 	return Bzr

--- a/hg.go
+++ b/hg.go
@@ -63,6 +63,11 @@ type HgRepo struct {
 	base
 }
 
+// SetRecursive is not used for hg repositories.
+func (HgRepo) SetRecursive(bool) {
+	// Do Nothing
+}
+
 // Vcs retrieves the underlying VCS being implemented.
 func (s HgRepo) Vcs() Type {
 	return Hg

--- a/repo.go
+++ b/repo.go
@@ -136,6 +136,10 @@ type Repo interface {
 
 	// ExportDir exports the current revision to the passed in directory.
 	ExportDir(string) error
+
+	// SetRecursive allows setting if the recursive option should be used
+	// with Git submodule calls.  This only applies to Git.
+	SetRecursive(bool)
 }
 
 // NewRepo returns a Repo based on trying to detect the source control from the

--- a/svn.go
+++ b/svn.go
@@ -65,6 +65,11 @@ type SvnRepo struct {
 	base
 }
 
+// SetRecursive is not used for svn repositories.
+func (SvnRepo) SetRecursive(bool) {
+	// Do Nothing
+}
+
 // Vcs retrieves the underlying VCS being implemented.
 func (s SvnRepo) Vcs() Type {
 	return Svn


### PR DESCRIPTION
This is a setting that I've found can be necessary for repositories that have broken `.gitmodules` files in them.  This is necessary for a related PR I am submitting for the `glide` tool as it fails to check out the `git2go` project.  I will explain further the reasoning in that PR.

For this PR I have just added an option that can be set that only affects Git repositories and just prevents use of the `--recursive` option if the `Recursive` field is set to `false` on the repo struct.