### PR TITLE
fix calling UpdateVersion with an empty string on git 2.16+

### DIFF
--- a/git.go
+++ b/git.go
@@ -369,20 +369,20 @@ func (s *GitRepo) Ping() bool {
 
 // EscapePathSeparator escapes the path separator by replacing it with several.
 // Note: this is harmless on Unix, and needed on Windows.
-func EscapePathSeparator(path string) (string) {
+func EscapePathSeparator(path string) string {
 	switch runtime.GOOS {
 	case `windows`:
 		// On Windows, triple all path separators.
 		// Needed to escape backslash(s) preceding doublequotes,
 		// because of how Windows strings treats backslash+doublequote combo,
 		// and Go seems to be implicitly passing around a doublequoted string on Windows,
-		// so we cannnot use default string instead.
+		// so we cannot use default string instead.
 		// See: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
 		// e.g., C:\foo\bar\ -> C:\\\foo\\\bar\\\
 		// used with --prefix, like this: --prefix=C:\foo\bar\ -> --prefix=C:\\\foo\\\bar\\\
 		return strings.Replace(path,
 			string(os.PathSeparator),
-			string(os.PathSeparator) + string(os.PathSeparator) + string(os.PathSeparator),
+			string(os.PathSeparator)+string(os.PathSeparator)+string(os.PathSeparator),
 			-1)
 	default:
 		return path
@@ -407,7 +407,7 @@ func (s *GitRepo) ExportDir(dir string) error {
 		return NewLocalError("Unable to create directory", err, "")
 	}
 
-	path = EscapePathSeparator( dir )
+	path = EscapePathSeparator(dir)
 	out, err := s.RunFromDir("git", "checkout-index", "-f", "-a", "--prefix="+path)
 	s.log(out)
 	if err != nil {
@@ -415,7 +415,7 @@ func (s *GitRepo) ExportDir(dir string) error {
 	}
 
 	// and now, the horror of submodules
-	path = EscapePathSeparator( dir + "$path" + string(os.PathSeparator) )
+	path = EscapePathSeparator(dir + "$path" + string(os.PathSeparator))
 	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git checkout-index -f -a --prefix="+path)
 	s.log(out)
 	if err != nil {

--- a/git.go
+++ b/git.go
@@ -158,9 +158,12 @@ func (s *GitRepo) Update() error {
 
 // UpdateVersion sets the version of a package currently checked out via Git.
 func (s *GitRepo) UpdateVersion(version string) error {
-	out, err := s.RunFromDir("git", "checkout", version)
-	if err != nil {
-		return NewLocalError("Unable to update checked out version", err, string(out))
+	// NOTE: as of git 2.16, `git checkout ""` returns an error. On previous releases this was a no-op.
+	if version != "" {
+		out, err := s.RunFromDir("git", "checkout", version)
+		if err != nil {
+			return NewLocalError("Unable to update checked out version", err, string(out))
+		}
 	}
 
 	return s.defendAgainstSubmodules()

--- a/git_test.go
+++ b/git_test.go
@@ -565,7 +565,6 @@ func TestGitSubmoduleHandling2(t *testing.T) {
 		t.Errorf("Current failed to detect Git on tip of master. Got version: %s", v)
 	}
 
-
 	tempDir2, err := ioutil.TempDir("", "go-vcs-git-tests-export")
 	if err != nil {
 		t.Fatalf("Error creating temp directory: %s", err)
@@ -589,7 +588,7 @@ func TestGitSubmoduleHandling2(t *testing.T) {
 		t.Errorf("Error checking exported file in Git: %s", err)
 	}
 
-	_, err = os.Stat(filepath.Join( filepath.Join(exportDir, "definitions"), "README.md"))
+	_, err = os.Stat(filepath.Join(filepath.Join(exportDir, "definitions"), "README.md"))
 	if err != nil {
 		t.Errorf("Error checking exported file in Git: %s", err)
 	}

--- a/git_test.go
+++ b/git_test.go
@@ -98,6 +98,12 @@ func TestGit(t *testing.T) {
 		t.Errorf("Unable to update Git repo version. Err was %s", err)
 	}
 
+	// ensure that supplying an empty string is a no-op.
+	err = repo.UpdateVersion("")
+	if err != nil {
+		t.Errorf("Unable to update Git repo version. Err was %s", err)
+	}
+
 	// Once a ref has been checked out the repo is in a detached head state.
 	// Trying to pull in an update in this state will cause an error. Update
 	// should cleanly handle this. Pulling on a branch (tested elsewhere) and

--- a/vcs_remote_lookup_test.go
+++ b/vcs_remote_lookup_test.go
@@ -34,7 +34,6 @@ func TestVCSLookup(t *testing.T) {
 		"https://example.com/foo/bar/baz.hg":                               {work: true, t: Hg},
 		"https://gopkg.in/tomb.v1":                                         {work: true, t: Git},
 		"https://golang.org/x/net":                                         {work: true, t: Git},
-		"https://speter.net/go/exp/math/dec/inf":                           {work: true, t: Git},
 		"https://git.openstack.org/foo/bar":                                {work: true, t: Git},
 		"git@github.com:Masterminds/vcs.git":                               {work: true, t: Git},
 		"git@example.com:foo.git":                                          {work: true, t: Git},


### PR DESCRIPTION
As of git 2.16, they've now deprecated `git checkout ""` as being a no-op. Instead it now returns an error.