### PR TITLE
hg: disable extensions

### DIFF
--- a/hg.go
+++ b/hg.go
@@ -25,7 +25,11 @@ func NewHgRepo(remote, local string) (*HgRepo, error) {
 		return nil, ErrWrongVCS
 	}
 
-	r := &HgRepo{}
+	r := &HgRepo{
+		base{
+			envOverride: []string{"HGRCPATH="},
+		},
+	}
 	r.setRemote(remote)
 	r.setLocalPath(local)
 	r.Logger = Logger

--- a/repo.go
+++ b/repo.go
@@ -191,6 +191,7 @@ type CommitInfo struct {
 type base struct {
 	remote, local string
 	Logger        *log.Logger
+	envOverride   []string
 }
 
 func (b *base) log(v interface{}) {
@@ -227,7 +228,7 @@ func (b base) run(cmd string, args ...string) ([]byte, error) {
 func (b *base) CmdFromDir(cmd string, args ...string) *exec.Cmd {
 	c := exec.Command(cmd, args...)
 	c.Dir = b.local
-	c.Env = envForDir(c.Dir)
+	c.Env = append(envForDir(c.Dir), b.envOverride...)
 	return c
 }
 


### PR DESCRIPTION
Extensions have the potential to alter significantly the observable behavior of
mercurial, thus breaking the parsing logic in this package.
For example the Version() operation, by using "--debug", breaks whenever an
extension is loaded that adds debug output upon initialization.

Note: this *could* also break current downstream consumers, who currently rely on their extensions being picked up while being silent enough that they don't mess with the output... Thoughts?