### PR TITLE
bug fix for CRLF

### DIFF
--- a/svn.go
+++ b/svn.go
@@ -375,6 +375,10 @@ func detectRemoteFromInfoCommand(infoOut string) (string, error) {
 		return "", fmt.Errorf("Remote not specified in svn info")
 	}
 	urlEndIndex := strings.Index(string(sBytes[urlIndex:]), "\n")
+	urlEndIndexCRLF := strings.Index(string(sBytes[urlIndex:]), "\r\n")
+	if urlEndIndexCRLF != -1 {
+		urlEndIndex = urlEndIndexCRLF
+	}
 	if urlEndIndex == -1 {
 		urlEndIndex = strings.Index(string(sBytes[urlIndex:]), "\r")
 		if urlEndIndex == -1 {


### PR DESCRIPTION
bug fix for CRLF, in windows platform.
When I use svn mirror for glide. use crlf,that will catch a errlr:

[ERROR] Failed to set version on github.com/kataras/iris to : The Remote does not match the VCS endpoint