### PR TITLE
Return an error if Version() prints to stderr

### DIFF
--- a/hg_test.go
+++ b/hg_test.go
@@ -2,12 +2,11 @@ package vcs
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
-	"time"
-	//"log"
-	"os"
 	"testing"
+	"time"
 )
 
 // Canary test to ensure HgRepo implements the Repo interface.


### PR DESCRIPTION
We call `hg --debug identify` to get the version, but this command can
print warnings to stderr. Previously we would read the first line as
the version, which would try to parse whatever warning was printed as
the version.

Instead parse stdout and stderr separately and return an error if
anything gets sent to stderr. This should at least alert people to the
problem and avoid percolating problems further downstream.

Fixes #90.