### PR TITLE
Allow non-200 remote lookup responses

### DIFF
--- a/vcs_remote_lookup.go
+++ b/vcs_remote_lookup.go
@@ -109,14 +109,6 @@ func detectVcsFromRemote(vcsURL string) (Type, string, error) {
 		return NoVCS, "", ErrCannotDetectVCS
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if resp.StatusCode == 404 {
-			return NoVCS, "", NewRemoteError(fmt.Sprintf("%s Not Found", vcsURL), nil, "")
-		} else if resp.StatusCode == 401 || resp.StatusCode == 403 {
-			return NoVCS, "", NewRemoteError(fmt.Sprintf("%s Access Denied", vcsURL), nil, "")
-		}
-		return NoVCS, "", ErrCannotDetectVCS
-	}
 
 	t, nu, err := parseImportFromBody(u, resp.Body)
 	if err != nil {

--- a/vcs_remote_lookup_test.go
+++ b/vcs_remote_lookup_test.go
@@ -110,27 +110,3 @@ func TestVCSFileLookup(t *testing.T) {
 		t.Errorf("Detected wrong type from file:// path. Found type %v", ty)
 	}
 }
-
-func TestNotFound(t *testing.T) {
-	_, _, err := detectVcsFromRemote("https://mattfarina.com/notfound")
-	if err == nil || !strings.HasSuffix(err.Error(), " Not Found") {
-		t.Errorf("Failed to find not found repo")
-	}
-
-	_, err = NewRepo("https://mattfarina.com/notfound", "")
-	if err == nil || !strings.HasSuffix(err.Error(), " Not Found") {
-		t.Errorf("Failed to find not found repo")
-	}
-}
-
-func TestAccessDenied(t *testing.T) {
-	_, _, err := detectVcsFromRemote("https://bitbucket.org/mattfarina/private-repo-for-vcs-testing")
-	if err == nil || err.Error() != "Access Denied" {
-		t.Errorf("Failed to detect access denied")
-	}
-
-	_, err = NewRepo("https://bitbucket.org/mattfarina/private-repo-for-vcs-testing", "")
-	if err == nil || err.Error() != "Access Denied" {
-		t.Errorf("Failed to detect access denied")
-	}
-}


### PR DESCRIPTION
This mirrors the behaviour of the official go tool – it is valid to serve meta imports from e.g. 404 pages. Gonum does this, for instance: https://gonum.org/v1/gonum.

https://github.com/golang/go/blob/50bd1c4d4eb4fac8ddeb5f063c099daccfb71b26/src/cmd/go/internal/web/http.go#L113-L114