### PR TITLE
Fix clean of submodule on Linux

### DIFF
--- a/git.go
+++ b/git.go
@@ -181,7 +181,12 @@ func (s *GitRepo) defendAgainstSubmodules() error {
 		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict submodule directories", err, string(out))
 	}
 	// Then, repeat just in case there are any nested submodules that went away.
-	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git", "clean", "-x", "-d", "-f", "-f")
+	if runtime.GOOS == "windows" {
+		out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git", "clean", "-x", "-d", "-f", "-f")
+	} else {
+		out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git clean -x -d -f -f")
+	}
+
 	if err != nil {
 		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict nested submodule directories", err, string(out))
 	}


### PR DESCRIPTION
This fixes an issue with `dep` tool that uses vcs package:

```
$ dep ensure -add github.com/openSUSE/umoci
Fetching sources...

Solving failure: No versions of github.com/openSUSE/umoci met constraints:
	v0.4.4: unexpected error while defensively cleaning up after possible derelict nested submodule directories: Entering '.site/themes/hugo-theme-learn'
error: unknown switch `x'
usage: git submodule--helper foreach [--quiet] [--recursive] <command>

    -q, --quiet           Suppress output of entering each submodule command
    --recursive           Recurse into nested submodules

fatal: run_command returned non-zero status while recursing in the nested submodules of .site/themes/hugo-theme-learn
.
```

I see that this change is been done for Windows. Let me know if the chosen solution could be fine.