### PR TITLE
git: fix "git clean" invocation for submodule

### DIFF
--- a/git.go
+++ b/git.go
@@ -181,7 +181,7 @@ func (s *GitRepo) defendAgainstSubmodules() error {
 		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict submodule directories", err, string(out))
 	}
 	// Then, repeat just in case there are any nested submodules that went away.
-	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git", "clean", "-x", "-d", "-f", "-f")
+	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git clean -x -d -f -f")
 	if err != nil {
 		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict nested submodule directories", err, string(out))
 	}


### PR DESCRIPTION
The command passed after a "git submodule foreach" should be invoked
as a single string, as it is on line 416 of this file. Otherwise "-x"
is treated as an argument to "foreach" and it errors. See
golang/dep#2176 for more details.