### PR TITLE
compatible with git submodule command of version 2.22.0

### DIFF
--- a/git.go
+++ b/git.go
@@ -181,7 +181,7 @@ func (s *GitRepo) defendAgainstSubmodules() error {
 		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict submodule directories", err, string(out))
 	}
 	// Then, repeat just in case there are any nested submodules that went away.
-	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git", "clean", "-x", "-d", "-f", "-f")
+	out, err = s.RunFromDir("git", "submodule", "foreach", "--recursive", "git clean -x -d -f -f")
 	if err != nil {
 		return NewLocalError("Unexpected error while defensively cleaning up after possible derelict nested submodule directories", err, string(out))
 	}


### PR DESCRIPTION
**compatible with git submodule command of version 2.22.0**

I use git of version 2.22.0 run `glide install`,then report error:
```
Entering 'mustache'
error: unknown switch `x'
usage: git submodule--helper foreach [--quiet] [--recursive] [--] <command>

    -q, --quiet           Suppress output of entering each submodule command
    --recursive           Recurse into nested submodules

fatal: run_command returned non-zero status while recursing in the nested submodules of mustache
.
```
It seems that the option 'x' been treated as submodule command's option。