### PR TITLE
Fixing path in git integration tests

### DIFF
--- a/git_test.go
+++ b/git_test.go
@@ -586,7 +586,7 @@ func TestGitSubmoduleHandling2(t *testing.T) {
 		t.Errorf("Error checking exported file in Git: %s", err)
 	}
 
-	_, err = os.Stat(filepath.Join(filepath.Join(exportDir, "definitions"), "README.md"))
+	_, err = os.Stat(filepath.Join(filepath.Join(exportDir, "dropsonde-protocol"), "README.md"))
 	if err != nil {
 		t.Errorf("Error checking exported file in Git: %s", err)
 	}


### PR DESCRIPTION
The codebase used for git modules testing has changes since there was previous development. This updates the path to the current state of the repository being cloned so the test can continue.

Note: some tests are still failing. This change only fixes the git testing issues.