### PR TITLE
Fix svn tests

### DIFF
--- a/repo_test.go
+++ b/repo_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"testing"
 )
 
@@ -29,36 +28,6 @@ func ExampleNewRepo() {
 	// branch, or tag.
 	if err != nil {
 		fmt.Println(err)
-	}
-}
-
-func TestTypeSwitch(t *testing.T) {
-
-	// To test repo type switching we checkout as SVN and then try to get it as
-	// a git repo afterwards.
-	tempDir, err := ioutil.TempDir("", "go-vcs-svn-tests")
-	if err != nil {
-		t.Error(err)
-	}
-	defer func() {
-		err = os.RemoveAll(tempDir)
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
-	repo, err := NewSvnRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir+string(os.PathSeparator)+"VCSTestRepo")
-	if err != nil {
-		t.Error(err)
-	}
-	err = repo.Get()
-	if err != nil {
-		t.Errorf("Unable to checkout SVN repo for repo switching tests. Err was %s", err)
-	}
-
-	_, err = NewRepo("https://github.com/Masterminds/VCSTestRepo", tempDir+string(os.PathSeparator)+"VCSTestRepo")
-	if err != ErrWrongVCS {
-		t.Errorf("Not detecting repo switch from SVN to Git")
 	}
 }
 

--- a/svn.go
+++ b/svn.go
@@ -294,6 +294,10 @@ func (s *SvnRepo) CommitInfo(id string) (*CommitInfo, error) {
 
 	out, err := s.RunFromDir("svn", "log", "-r", id, "--xml")
 	if err != nil {
+		// Newer versions of svn can return an error here if a revision is not found.
+		if strings.Contains(string(out), "No such revision") {
+			return nil, ErrRevisionUnavailable
+		}
 		return nil, NewRemoteError("Unable to retrieve commit information", err, string(out))
 	}
 

--- a/svn_test.go
+++ b/svn_test.go
@@ -29,7 +29,7 @@ func TestSvn(t *testing.T) {
 		}
 	}()
 
-	repo, err := NewSvnRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir+string(os.PathSeparator)+"VCSTestRepo")
+	repo, err := NewSvnRepo("https://svn.riouxsvn.com/vcs-test/trunk", tempDir+string(os.PathSeparator)+"VCSTestRepo")
 	if err != nil {
 		t.Error(err)
 	}
@@ -39,7 +39,7 @@ func TestSvn(t *testing.T) {
 	}
 
 	// Check the basic getters.
-	if repo.Remote() != "https://github.com/Masterminds/VCSTestRepo/trunk" {
+	if repo.Remote() != "https://svn.riouxsvn.com/vcs-test/trunk" {
 		t.Error("Remote not set properly")
 	}
 	if repo.LocalPath() != tempDir+string(os.PathSeparator)+"VCSTestRepo" {
@@ -60,7 +60,7 @@ func TestSvn(t *testing.T) {
 	}
 
 	// Verify an incorrect remote is caught when NewSvnRepo is used on an existing location
-	_, nrerr := NewSvnRepo("https://github.com/Masterminds/VCSTestRepo/unknownbranch", tempDir+"/VCSTestRepo")
+	_, nrerr := NewSvnRepo("https://svn.riouxsvn.com/vcs-test/unknownbranch", tempDir+"/VCSTestRepo")
 	if nrerr != ErrWrongRemote {
 		t.Error("ErrWrongRemote was not triggered for SVN")
 	}
@@ -80,7 +80,7 @@ func TestSvn(t *testing.T) {
 	//
 	// Test NewRepo on existing checkout. This should simply provide a working
 	// instance without error based on looking at the local directory.
-	// nrepo, nrerr := NewRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir+"/VCSTestRepo")
+	// nrepo, nrerr := NewRepo("https://svn.riouxsvn.com/vcs-test/trunk", tempDir+"/VCSTestRepo")
 	// if nrerr != nil {
 	// 	t.Error(nrerr)
 	// }
@@ -137,7 +137,8 @@ func TestSvn(t *testing.T) {
 
 	// Use Date to verify we are on the right commit.
 	d, err := repo.Date()
-	if d.Format(longForm) != "2015-07-29 13:47:03 +0000" {
+	if d.Format(longForm) != "2025-04-07 16:01:46 +0000" {
+		t.Logf("%s\n", d.Format(longForm))
 		t.Error("Error checking checked out Svn commit date")
 	}
 	if err != nil {
@@ -168,7 +169,7 @@ func TestSvn(t *testing.T) {
 		t.Error("Svn is incorrectly returning branches")
 	}
 
-	if !repo.IsReference("r4") {
+	if !repo.IsReference("r3") {
 		t.Error("Svn is reporting a reference is not one")
 	}
 
@@ -187,22 +188,32 @@ func TestSvn(t *testing.T) {
 	if ci.Commit != "2" {
 		t.Error("Svn.CommitInfo wrong commit id")
 	}
-	if ci.Author != "matt.farina" {
+	if ci.Author != "mattfarina" {
+		t.Logf("%s\n", ci.Author)
 		t.Error("Svn.CommitInfo wrong author")
 	}
-	if ci.Message != "Update README.md" {
+	if ci.Message != "Adding readme" {
+		t.Logf("%s\n", ci.Message)
 		t.Error("Svn.CommitInfo wrong message")
 	}
-	ti, err := time.Parse(time.RFC3339Nano, "2015-07-29T13:46:20.000000Z")
+	ti, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2025-04-07 16:00:29.418991 +0000 UTC")
 	if err != nil {
 		t.Error(err)
 	}
 	if !ti.Equal(ci.Date) {
+		t.Logf("%s\n", ti.String())
+		t.Logf("%s\n", ci.Date)
 		t.Error("Svn.CommitInfo wrong date")
 	}
 
 	_, err = repo.CommitInfo("555555555")
 	if err != ErrRevisionUnavailable {
+		if ve, ok := err.(*RemoteError); ok {
+			t.Log(ve.Out())
+		} else {
+			t.Log("unable to type switch")
+		}
+		t.Logf("%s\n", err)
 		t.Error("Svn didn't return expected ErrRevisionUnavailable")
 	}
 
@@ -260,7 +271,7 @@ func TestSvnCheckLocal(t *testing.T) {
 
 	// Test NewRepo when there's no local. This should simply provide a working
 	// instance without error based on looking at the remote localtion.
-	_, nrerr := NewRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir+"/VCSTestRepo")
+	_, nrerr := NewRepo("https://svn.riouxsvn.com/vcs-test/trunk", tempDir+"/VCSTestRepo")
 	if nrerr != nil {
 		t.Error(nrerr)
 	}
@@ -278,7 +289,7 @@ func TestSvnPing(t *testing.T) {
 		}
 	}()
 
-	repo, err := NewSvnRepo("https://github.com/Masterminds/VCSTestRepo/trunk", tempDir)
+	repo, err := NewSvnRepo("https://svn.riouxsvn.com/vcs-test/trunk", tempDir)
 	if err != nil {
 		t.Error(err)
 	}

--- a/vcs_remote_lookup.go
+++ b/vcs_remote_lookup.go
@@ -74,6 +74,11 @@ var vcsList = []*vcsInfo{
 		pattern: `^(svn.code.sf.net/p/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)*$`,
 		vcs:     Svn,
 	},
+	{
+		host:    "svn.riouxsvn.com",
+		pattern: `^(svn.riouxsvn.com/[A-Za-z0-9_.\-]+(.*)?)*$`,
+		vcs:     Svn,
+	},
 	// If none of the previous detect the type they will fall to this looking for the type in a generic sense
 	// by the extension to the path.
 	{

--- a/vcs_remote_lookup_test.go
+++ b/vcs_remote_lookup_test.go
@@ -46,6 +46,8 @@ func TestVCSLookup(t *testing.T) {
 		"http://hg.code.sf.net/p/masterminds/test":                         {work: true, t: Hg},
 		"http://git.code.sf.net/p/masterminds/test":                        {work: true, t: Git},
 		"http://svn.code.sf.net/p/masterminds/test":                        {work: true, t: Svn},
+		"https://svn.riouxsvn.com/vcs-test/trunk":                          {work: true, t: Svn},
+		"https://svn.riouxsvn.com/vcs-test":                                {work: true, t: Svn},
 	}
 
 	for u, c := range urlList {


### PR DESCRIPTION
Note: the test to detect a change in underlying VCS was removed. This test detected when SVN was retrieved from GitHub but it supplied a .git directory which was locally detected as Git instead of svn. Since GitHub has dropped svn support there is no place to test this with integration tests.